### PR TITLE
Spike email content in code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,9 +11,12 @@ gem "pg", "~> 1.1"
 gem "propshaft"
 gem "puma", ">= 5.0"
 gem "tzinfo-data", platforms: %i[windows jruby]
+gem "dotenv-rails"
 
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
+
+gem "mail-notify"
 
 group :development, :test do
   gem "debug", platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,10 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
+    dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
     factory_bot (6.4.6)
@@ -133,6 +137,8 @@ GEM
     jsbundling-rails (1.3.0)
       railties (>= 6.0.0)
     json (2.7.2)
+    jwt (2.8.2)
+      base64
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -142,6 +148,13 @@ GEM
       net-imap
       net-pop
       net-smtp
+    mail-notify (2.0.0)
+      actionmailer (>= 5.2.8.1)
+      actionpack (>= 5.2.8.1)
+      actionview (>= 5.2.8.1)
+      activesupport (>= 5.2.8.1)
+      notifications-ruby-client (~> 6.0)
+      rack (>= 2.1.4.1)
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
@@ -171,6 +184,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
+    notifications-ruby-client (6.1.0)
+      jwt (>= 1.5, < 3)
     pagy (8.6.3)
     parallel (1.25.1)
     parser (3.3.4.0)
@@ -319,11 +334,13 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv-rails
   factory_bot_rails
   faker
   govuk-components
   govuk_design_system_formbuilder
   jsbundling-rails
+  mail-notify
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+class ApplicationMailer < Mail::Notify::Mailer
+  NOTIFY_TEMPLATE_ID = "c437a1cb-9e1c-49ff-83ee-967c92f95637"
+
   layout "mailer"
 end

--- a/app/mailers/example_mailer.rb
+++ b/app/mailers/example_mailer.rb
@@ -1,0 +1,9 @@
+class ExampleMailer < ApplicationMailer
+  def hello_world
+    to = params[:to]
+    subject = params[:subject]
+    @recipient = Data.define(:full_name).new(full_name: "Herbert M Anchovy")
+
+    view_mail(NOTIFY_TEMPLATE_ID, to:, subject:)
+  end
+end

--- a/app/views/example_mailer/hello_world.text.erb
+++ b/app/views/example_mailer/hello_world.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @recipient.full_name %>
+
+# Welcome to the example email for ECF2
+
+Here are some useless points:
+
+* Bananas are nice
+* So is cheese
+* Forty days and forty nights
+* is quite a long time
+
+^ Yes, you can use markdown
+

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,12 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  # GOVUK Notify
+  config.action_mailer.delivery_method = :notify
+  config.action_mailer.notify_settings = {
+    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY"),
+  }
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,6 +65,12 @@ Rails.application.configure do
   # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "ecf2_production"
 
+  # GOVUK Notify
+  config.action_mailer.delivery_method = :notify
+  config.action_mailer.notify_settings = {
+    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY"),
+  }
+
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/test/mailers/previews/example_mailer_preview.rb
+++ b/test/mailers/previews/example_mailer_preview.rb
@@ -1,0 +1,5 @@
+class ExampleMailerPreview < ActionMailer::Preview
+  def hello_world
+    ExampleMailer.with(to: "testbot@example.com", subject: "A nice preview").hello_world
+  end
+end


### PR DESCRIPTION
Spike using view based emails instead of template based email with Notify.
A basic template is needed in Notify with placeholders for the subject and body, then we can use maielrs and views in the code to supply the content for the email, keeping the mailer and template synchronised within the repo.

## Example Notify template
![image](https://github.com/user-attachments/assets/09af7b6c-ac29-43dc-813a-56d60d748974)

## Test message rendered on Notify
![image](https://github.com/user-attachments/assets/2b733981-dcc9-439c-a024-f760e1dfcfb9)

## Preview of the message using `ActionMailer::Preview` from the app
![image](https://github.com/user-attachments/assets/2df4664c-4bd1-42ec-b304-a07a7185e677)
