### PR TITLE
Disable `active_record.belongs_to_required_by_default` by default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,6 @@ module Ecf2
     config.autoload_lib(ignore: %w[assets tasks])
     config.assets.paths << Rails.root.join('node_modules/govuk-frontend/dist/govuk/assets')
     config.exceptions_app = routes
+    config.active_record.belongs_to_required_by_default = false
   end
 end


### PR DESCRIPTION
When Rails 5.1 was released belongs_to requires by default that the related record exists. When the relation is we have to add optional: true

Unfortunately this has the side effect of [adding errors to the relationship instead of the foreign key field](https://github.com/rails/rails/pull/46494). So, if we have:

```ruby
class Subject < ActiveRecord::Base
  belongs_to :teacher
end
```

and in our form, something like:

```erb
<%= govuk_collection_radio_buttons :teacher_id, @teachers, :id, :name %>
```

If no teacher is selected the error will be added to subject on the `teacher` field, which isn't present in the form, leading to a mismatch between the `govuk_error_summary` and the form field. The radio collection won't be highlighted in red and the link from the error summary won't match the id of the first radio button input.

I suggest we disable [active_record.belongs_to_required_by_default](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-record-belongs-to-required-by-default-option) from the beginning and add validation explicitly.
