### PR TITLE
Remove placeholder title text from the general ticket template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-ticket.md
+++ b/.github/ISSUE_TEMPLATE/general-ticket.md
@@ -1,7 +1,7 @@
 ---
 name: General ticket
 about: A simple template for most tickets.
-title: Insert title for ticket
+title: ''
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
When creating a new issue the 'Submit new issue' button won't be enabled until a title is entered. When there's placeholder text in the button is enabled from the start and there's a greater chance of someone (me!) submitting it with the default text.

Having a blank title forces the reporter to add something.
