### PR TITLE
Add `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+# https://EditorConfig.org
+# https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/editorconfig
+root = true
+
+[*.{adoc,css,erb,js,json,md,rb,scss,sh,yaml,yml}]
+indent_size = 2
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_size = 2
+indent_style = tab
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.sql]
+indent_size = 4
+indent_style = space
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[**vendor**]
+indent_size = unset
+indent_style = unset
+charset = unset
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+max_line_length = unset


### PR DESCRIPTION
This is largely lifted from [The GDS Way](https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages.html) but I've condensed it to remove some repetition.

The two outliers are Makefile which needs tabs instead of spaces and SQL which is more readable with extra indentation
