### PR TITLE
Add basic Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    labels:
+      - Dependencies
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    labels:
+      - Dependencies
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    labels:
+      - Dependencies


### PR DESCRIPTION
This adds a basic config for Ruby, JS and GitHub Actions. We'll start off with a limit of 5 pull requests for each ecosystem.

Keeping it simple for now as we have very few dependencies, will (possibly) worry about groups later.
