### PR TITLE
Tweak generators so less cleanup required

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,15 @@ module Ecf2
     config.assets.paths << Rails.root.join('node_modules/govuk-frontend/dist/govuk/assets')
     config.exceptions_app = routes
     config.active_record.belongs_to_required_by_default = false
+
+    config.generators do |g|
+      g.helper(false)
+      g.factory_bot(suffix: "factory")
+      g.test_framework(:rspec,
+                       fixtures: false,
+                       view_specs: false,
+                       controller_specs: false,
+                       helper_specs: false)
+    end
   end
 end


### PR DESCRIPTION
By default Rails will generate lots of helpful files so you can fill in the blanks. We only want a subset so:

* we're disabling helpers by default, they're easy enough to add on an
  ad hoc basis if we need them
* fixtures - unused
* view specs - unused
* controller specs - unused, use request specs instead
* helper specs - add manually if required

Also, suffix the factories with `_factory` to make them easier to fuzzy find.


## Example calls

### Before

```
be rails g model apple
      invoke  active_record
      create    db/migrate/20240805102347_create_apples.rb
      create    app/models/apple.rb
      invoke    rspec
      create      spec/models/apple_spec.rb
      invoke      factory_bot
      create        spec/factories/apples.rb
```

```
be rails g controller apple
      create  app/controllers/apple_controller.rb
      invoke  erb
      create    app/views/apple
      invoke  rspec
      create    spec/requests/apple_spec.rb
      invoke  helper
      create    app/helpers/apple_helper.rb
      invoke    rspec
      create      spec/helpers/apple_helper_spec.rb
```

### After

```
be rails g model apple
      invoke  active_record
      create    db/migrate/20240805102150_create_apples.rb
      create    app/models/apple.rb
      invoke    rspec
      create      spec/models/apple_spec.rb
      invoke      factory_bot
      create        spec/factories/apples_factory.rb
```

```
be rails g controller apple
      create  app/controllers/apple_controller.rb
      invoke  erb
      create    app/views/apple
      invoke  rspec
      create    spec/requests/apple_spec.rb
```


