### PR TITLE
Move previews to /spec and fix bug in example

### DIFF
--- a/spec/mailers/previews/example_mailer_preview.rb
+++ b/spec/mailers/previews/example_mailer_preview.rb
@@ -1,0 +1,5 @@
+class ExampleMailerPreview < ActionMailer::Preview
+  def hello_world
+    ExampleMailer.with(to: "testbot@example.com", subject: "A nice preview", salutation: "G'day").hello_world
+  end
+end

--- a/test/mailers/previews/example_mailer_preview.rb
+++ b/test/mailers/previews/example_mailer_preview.rb
@@ -1,5 +1,0 @@
-class ExampleMailerPreview < ActionMailer::Preview
-  def hello_world
-    ExampleMailer.with(to: "testbot@example.com", subject: "A nice preview").hello_world
-  end
-end


### PR DESCRIPTION
Move mailer previews to `/spec` instead of `/test` to tidy up the root folder and fix a bug in the example preview