### PR TITLE
Improve documentation site reloading

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,8 @@ group :test do
   gem "capybara"
 end
 
-group :documentation do
+group :nanoc do
   gem "asciidoctor"
   gem "nanoc"
+  gem "nanoc-live"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,15 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    adsf (1.5.0)
+      rack (>= 1.0.0, < 4.0.0)
+      rackup (~> 2.1)
+    adsf-live (1.5.0)
+      adsf (~> 1.3)
+      em-websocket (~> 0.5)
+      eventmachine (~> 1.2)
+      listen (~> 3.0)
+      rack-livereload (~> 0.3)
     asciidoctor (2.0.23)
     ast (2.4.2)
     base64 (0.2.0)
@@ -109,7 +118,11 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
     drb (2.2.1)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
     erubi (1.13.0)
+    eventmachine (1.2.7)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -117,6 +130,12 @@ GEM
       railties (>= 5.0.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     govuk-components (5.4.1)
@@ -133,6 +152,7 @@ GEM
       redcarpet
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
+    http_parser.rb (0.8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     immutable-ruby (0.2.0)
@@ -149,6 +169,9 @@ GEM
     jwt (2.8.2)
       base64
     language_server-protocol (3.17.0.3)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -207,6 +230,11 @@ GEM
       nanoc-checking (~> 1.0)
       nanoc-cli (~> 4.11, >= 4.11.15)
       nanoc-core (~> 4.11, >= 4.11.15)
+    nanoc-live (1.1.0)
+      adsf-live (~> 1.4)
+      listen (~> 3.0)
+      nanoc-cli (~> 4.11, >= 4.11.14)
+      nanoc-core (~> 4.11, >= 4.11.14)
     net-imap (0.4.14)
       date
       net-protocol
@@ -254,6 +282,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.7)
+    rack-livereload (0.5.1)
+      rack
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -292,6 +322,9 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rbtree (0.4.6)
     rdoc (6.7.0)
       psych (>= 4.0.0)
@@ -405,6 +438,7 @@ DEPENDENCIES
   jsbundling-rails
   mail-notify
   nanoc
+  nanoc-live
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
-watch-documentation-site:
-	ls documentation/site/content/**/* | entr -s "cd documentation/site && bundle exec nanoc"
-
 serve-documentation-site:
-	cd documentation/site/output && ruby -run -e httpd . -p 8000
+	cd documentation/site && bundle exec nanoc live --handler webrick --port 8000
 
 build-documentation-site:
 	cd documentation/site && bundle exec nanoc


### PR DESCRIPTION
Use [nanoc-live](https://nanoc.app/doc/sites/#compiling-a-site) instead of relying on `entr` and specifying what files to watch. This should make working with the site when changing multiple file types (i.e., files other than markdown) a bit smoother.
