### PR TITLE
Add platform `x86_64-linux-musl` to bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,15 +130,16 @@ GEM
       railties (>= 5.0.0)
     faker (3.4.2)
       i18n (>= 1.8.11, < 2)
-    fugit (1.11.0)
-      et-orbi (~> 1, >= 1.2.11)
-      raabro (~> 1.4)
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-arm-linux-gnu)
     ffi (1.17.0-arm64-darwin)
     ffi (1.17.0-x86-linux-gnu)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
+    fugit (1.11.0)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
     govuk-components (5.4.1)
@@ -435,6 +436,7 @@ PLATFORMS
   x86-linux
   x86_64-darwin
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   asciidoctor
@@ -466,4 +468,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.11
+   2.5.17


### PR DESCRIPTION
The past work has been done on GNU based Linux systems but Alpine is [musl](https://www.musl-libc.org/) based so we need it too.

Fixes #126
