### PR TITLE
Make rspec and lint workflows reuseable with `on.workflow_call` trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: "Deploy"
+
+concurrency: build_and_deploy_${{ github.ref_name }}
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+
+  rspec:
+    name: RSpec
+    uses: ./.github/workflows/rspec.yml
+
+  all-checks-passed:
+    name: All checks passed
+    needs: [lint, rspec]
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo 'Linting and tests passed, this branch is ready to be merged'"
+
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
+    outputs:
+      docker-image: ${{ steps.build-docker-image.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DFE-Digital/github-actions/build-docker-image@master
+        id: build-docker-image
+        with:
+          docker-repository: ghcr.io/dfe-digital/ecf2
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,13 @@
 name: "Lint"
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      ruby-version:
+        description: Ruby version
+        type: string
+        required: false
+        default: "3.3.4"
+
 jobs:
   ruby_linting:
     name: "Lint ruby"

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,8 +1,13 @@
 name: "RSpec"
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      ruby-version:
+        description: Ruby version
+        type: string
+        required: false
+        default: "3.3.4"
+
 jobs:
   backend-tests:
     name: Run rspec

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY . .
 
 # Precompile assets
 RUN RAILS_ENV=production SECRET_KEY_BASE=required-to-run-but-not-used \
+    GOVUK_NOTIFY_API_KEY=TestKey \
     bundle exec rails assets:precompile
 
 # Cleanup to save space in the production image


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0f99fdcc-7008-4999-889a-66ec04fe2b4c)

Our deploy script needs to call lint and rspec. This will allow us to build `main` branch ghio images for use with deployments. A precursor to bringing up new environments.
