### PR TITLE
Add build image workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: "Deploy"
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+
+jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+
+  rspec:
+    name: RSpec
+    uses: ./.github/workflows/rspec.yml
+
+  all-checks-passed:
+    name: All checks passed
+    needs: [lint, rspec]
+    runs-on: ubuntu-latest
+    steps:
+      - run: "echo 'Linting and tests passed, this branch is ready to be merged'"
+
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
+    outputs:
+      docker-image: ${{ steps.build-docker-image.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DFE-Digital/github-actions/build-docker-image@master
+        id: build-docker-image
+        with:
+          docker-repository: ghcr.io/dfe-digital/ecf2
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,18 @@
 name: "Lint"
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      ruby-version:
+        description: Ruby version
+        type: string
+        required: false
+        default: "3.3.4"
+      node-version:
+        description: Node version
+        type: string
+        required: false
+        default: "20.15.1"
+
 jobs:
   ruby_linting:
     name: "Lint ruby"

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,8 +1,12 @@
 name: "RSpec"
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      ruby-version:
+        description: Ruby version
+        type: string
+        required: false
+        default: "3.3.4"
 jobs:
   backend-tests:
     name: Run rspec


### PR DESCRIPTION
Part of #7 

In order to deploy review apps we need a docker image in ghcr.io tagged with `main`.
This PR introduces the necessary workflow actions to build and push a docker image to ghcr.io when a pull request is merged.
We can then [add deploy workflows for review apps](https://github.com/DFE-Digital/ecf2/pull/142) and deployments to other environments.