### PR TITLE
Create product section and add scope and product principles documentation

### DIFF
--- a/documentation/site/content/index.html.erb
+++ b/documentation/site/content/index.html.erb
@@ -17,9 +17,17 @@ title: Early career framework documentation
 <h2 class="govuk-heading-m">Policy documentation</h2>
 
 <ul class="govuk-list">
-  <li><a href="/policy/induction-for-early-career-teachers/">Induction for early career teachers</a> </li>
+  <li><a href="/policy/induction-for-early-career-teachers/">Induction for early career teachers</a></li>
   <li><a href="/policy/induction-arrangements-for-school-teachers-in-england/">Induction arrangements for school teachers in England</a></li>
 </ul>
+
+<h2 class="govuk-heading-m">Product documentation</h2>
+
+<ul class="govuk-list">
+  <li><a href="/product/principles/">Principles</a></li>
+  <li><a href="/product/scope/">Scope</a></li>
+</ul>
+
 
 <h2 class="govuk-heading-m">Useful resources</h2>
 

--- a/documentation/site/content/index.html.erb
+++ b/documentation/site/content/index.html.erb
@@ -25,7 +25,7 @@ title: Early career framework documentation
 
 <ul class="govuk-list">
   <li><a href="/product/principles/">Our prioritisation principles for ECF2</a></li>
-  <li><a href="/product/scope/">What's in scope for ECF2</a></li>
+  <li><a href="/product/scope/">What’s in scope for ECF2</a></li>
 </ul>
 
 

--- a/documentation/site/content/index.html.erb
+++ b/documentation/site/content/index.html.erb
@@ -24,8 +24,8 @@ title: Early career framework documentation
 <h2 class="govuk-heading-m">Product documentation</h2>
 
 <ul class="govuk-list">
-  <li><a href="/product/principles/">Principles</a></li>
-  <li><a href="/product/scope/">Scope</a></li>
+  <li><a href="/product/principles/">Our prioritisation principles for ECF2</a></li>
+  <li><a href="/product/scope/">What's in scope for ECF2</a></li>
 </ul>
 
 

--- a/documentation/site/content/product/principles.md
+++ b/documentation/site/content/product/principles.md
@@ -1,0 +1,71 @@
+# Our prioritisation principles for ECF2
+
+## Why we wanted to have principles for how we prioritise in ECF2
+
+It's very easy to state what you're going to prioritise, but a lot harder to know what to prioritise _less_. 
+
+For example, our service, like many others, will attempt to prioritise meeting the needs of users and saving taxpayer money.
+
+Given the scale of the minimum viable product for ECF2, we thought it was important to write down some prioritisation principles to inform how we work.
+
+These are a work in progress, and will continue to be iterated over time.
+
+These principles are inspired by [Jeremy Keith's article, Principles and priorities.](https://medium.com/clear-left-thinking/principles-and-priorities-f7cd29a57a5d)
+
+## Flexibility over convenience
+
+We want our services to be flexible to the changes that might occur to early career teacher training.
+
+Sometimes, we might need to take the slightly longer way to do things to ensure it can be edited more easily in the future.
+
+For example, rather than have a table in our database for each distinct user group, we've decided to use a 'users' table with relationships to other tables.
+
+## Self-sustainability over building more
+
+We want to build features that users can use, without having to depend too much on support or even developer assistance.
+
+Whenever we build a feature, we should have in mind any support tooling it requires, and what we can do to make sure users can use it independently.
+
+For example, we want to try making adding an early career teacher record as easy as possible, as opposed to building a new feature to handle when early career teachers leave training.
+
+We should focus on getting these initial features right, to help save time for users and support and developers, rather than adding new features to address other needs or more generally experiment.
+
+## Transparency over process
+
+It is part of the service standards to be open. Many services in DfE already do this through having open source code and using design histories.
+
+For example, we decided to use Github rather than Jira for our sprint planning and documentation to help with this.
+
+We also thought it would help the organisation of our project. [You can read more about this decision in our Github discussion.](https://github.com/DFE-Digital/ecf2/discussions/46)
+
+## Evidenced problems over general improvements
+
+In the discovery for ECF2, we looked at the biggest problems for each of our user groups.
+
+We need to remember to focus on these biggest problems, rather than just generally trying to improve everything when rebuilding the service.
+
+For example, we decided to descope notifying users of changes to data till after our initial release. 
+
+This is because it is not something that currently is a massive pain point that is evidenced in user research, feedback surveys or support tickets.
+
+We know it will help meet user needs, but less significantly.
+
+Instead, we will prioritise on the top issues that generate lots of support tickets, like when we can't find early career teacher or mentor records in the database for qualified teachers.
+
+## Good over perfect
+
+This prioritisation principle should seem obvious, but has actually been the hardest to stick to so far.
+
+The existing services that maintain the early career teaching reforms have been around for over three years. There are a lot of thoughts on how to improve them.
+
+We need to be happy when we've gone a good way to solving the biggest problems, rather than waiting for perfection.
+
+It's important we release something for users sooner rather than later.
+
+For example, we're currently experimenting with using the name 'Register early career teachers'. This follows government design principles, but doesn't:
+- make clear users need to come back after initial registration if details change
+- include early career teacher mentors
+
+However, we think it's a good, short name we can use across our services for different user groups with less confusion than the current name.
+
+

--- a/documentation/site/content/product/principles.md
+++ b/documentation/site/content/product/principles.md
@@ -34,6 +34,7 @@ For example, we want to try making adding an early career teacher record as easy
 
 We should focus on getting these initial features right, to help save time for users and support and developers, rather than adding new features to address other needs or more generally experiment.
 
+This is also because we want to make sure the core foundations of the service work properly and without much assistance, before we add other new features.
 ## Transparency over process
 
 It is part of the service standards to be open. Many services in DfE already do this through having open source code and using design histories.

--- a/documentation/site/content/product/principles.md
+++ b/documentation/site/content/product/principles.md
@@ -22,6 +22,8 @@ Sometimes, we might need to take the slightly longer way to do things to ensure 
 
 For example, rather than have a table in our database for each distinct user group, we've decided to use a 'users' table with relationships to other tables. This means if the user groups involved in the services change, it should be easier to make the necessary changes to the data model.
 
+We sometimes might need to spend extra time to organise things nicely rather than taking the quicker option that is potentially less flexible.
+
 ## Self-sustainability over building more
 
 We want to build features that users can use, without having to depend too much on support or even developer assistance.

--- a/documentation/site/content/product/principles.md
+++ b/documentation/site/content/product/principles.md
@@ -36,7 +36,7 @@ It is part of the service standards to be open. Many services in DfE already do 
 
 For example, we decided to use Github rather than Jira for our sprint planning and documentation to help with this.
 
-We also thought it would help the organisation of our project. [You can read more about this decision in our Github discussion.](https://github.com/DFE-Digital/ecf2/discussions/46)
+[You can read more about this decision in our Github discussion.](https://github.com/DFE-Digital/ecf2/discussions/46)
 
 ## Evidenced problems over general improvements
 

--- a/documentation/site/content/product/principles.md
+++ b/documentation/site/content/product/principles.md
@@ -4,9 +4,9 @@
 
 It's very easy to state what you're going to prioritise, but a lot harder to know what to prioritise _less_. 
 
-For example, our service, like many others, will attempt to prioritise meeting the needs of users and saving taxpayer money.
+For example, our service, like many others, will attempt to prioritise meeting the needs of users and saving taxpayers' money.
 
-Given the scale of the minimum viable product for ECF2, we thought it was important to write down some prioritisation principles to inform how we work.
+[Given the scale of the minimum viable product for ECF2](https://teacher-cpd.design-history.education.gov.uk/ecf-v2/initial-release-of-ecf-2/), we thought it was important to write down some prioritisation principles to inform how we work.
 
 These are a work in progress, and will continue to be iterated over time.
 
@@ -40,7 +40,7 @@ For example, we decided to use Github rather than Jira for our sprint planning a
 
 ## Evidenced problems over general improvements
 
-In the discovery for ECF2, we looked at the biggest problems for each of our user groups.
+In the discovery for ECF2, [we looked at the biggest problems for each of our user groups.](https://teacher-cpd.design-history.education.gov.uk/ecf-v2/workshop-process/)
 
 We need to remember to focus on these biggest problems, rather than just generally trying to improve everything when rebuilding the service.
 

--- a/documentation/site/content/product/principles.md
+++ b/documentation/site/content/product/principles.md
@@ -4,7 +4,7 @@ title: Our prioritisation principles for ECF2
 
 ## Why we wanted to have principles for how we prioritise in ECF2
 
-It's very easy to state what you're going to prioritise, but a lot harder to know what to prioritise _less_. 
+It's very easy to state what you're going to prioritise, but a lot harder to know what to prioritise _less_.
 
 For example, our service, like many others, will attempt to prioritise meeting the needs of users and saving taxpayers' money.
 
@@ -46,7 +46,7 @@ In the discovery for ECF2, [we looked at the biggest problems for each of our us
 
 We need to remember to focus on these biggest problems, rather than just generally trying to improve everything when rebuilding the service.
 
-For example, we decided to descope notifying users of changes to data till after our initial release. 
+For example, we decided to descope notifying users of changes to data till after our initial release.
 
 This is because it is not something that currently is a massive pain point that is evidenced in user research, feedback surveys or support tickets.
 
@@ -69,5 +69,3 @@ For example, we're currently experimenting with using the name 'Register early c
 - include early career teacher mentors
 
 However, we think it's a good, short name we can use across our services for different user groups with less confusion than the current name.
-
-

--- a/documentation/site/content/product/principles.md
+++ b/documentation/site/content/product/principles.md
@@ -20,7 +20,7 @@ We want our services to be flexible to the changes that might occur to early car
 
 Sometimes, we might need to take the slightly longer way to do things to ensure it can be edited more easily in the future.
 
-For example, rather than have a table in our database for each distinct user group, we've decided to use a 'users' table with relationships to other tables.
+For example, rather than have a table in our database for each distinct user group, we've decided to use a 'users' table with relationships to other tables. This means if the user groups involved in the services change, it should be easier to make the necessary changes to the data model.
 
 ## Self-sustainability over building more
 
@@ -52,7 +52,7 @@ This is because it is not something that currently is a massive pain point that 
 
 We know it will help meet user needs, but less significantly.
 
-Instead, we will prioritise on the top issues that generate lots of support tickets, like when we can't find early career teacher or mentor records in the database for qualified teachers.
+Instead, we will prioritise issues that generate lots of support tickets, like when we can't find early career teacher or mentor records in the database for qualified teachers.
 
 ## Good over perfect
 

--- a/documentation/site/content/product/principles.md
+++ b/documentation/site/content/product/principles.md
@@ -1,4 +1,6 @@
-# Our prioritisation principles for ECF2
+---
+title: Our prioritisation principles for ECF2
+---
 
 ## Why we wanted to have principles for how we prioritise in ECF2
 

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -22,7 +22,7 @@ In this initial release, we're planning to include:
 
 - an easier way for schools to register their early career teachers and mentors with DfE, that also helps them understand their ECF responsibilities​
 - an [improved and simplified data model](https://teacher-cpd.design-history.education.gov.uk/ecf-v2/designing-the-database-first/) that better represents reality
-- an easier way for users to access the service, utilising [DfE Sign in](https://github.com/DFE-Digital/ecf2/discussions/43) and allowing multiple accounts per school
+- an easier way for users to access the service, utilising [DfE Sign in]([https://github.com/DFE-Digital/ecf2/discussions/43](https://teacher-cpd.design-history.education.gov.uk/ecf-v2/exploring-using-dfe-sign-in/)) and allowing multiple accounts per school
 - an API with improved validation rules, surfacing more information lead providers need and simplified where possible
 - improved API documentation, consistent with the NPQ API documentation
 - a way for appropriate bodies to check training data for early career teachers

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -55,6 +55,7 @@ We're hoping later to consider:
 - adding or making changes to early career teachers or mentors in bulk
 - if we need to store a preferred name for early career teachers or mentors, different to their legal name stored with their teaching record
 - if we need to store a preferred name for early career teachers or mentors, different to their legal name stored with their teaching record
+- if we need to store a preferred name for early career teachers or mentors, different to their legal name stored with their teaching record
 
 ## What's completely out of scope for ECF2
 

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -38,6 +38,7 @@ In this initial release, we're planning to include:
 - all changes related to contracts for 2025, and backwards compatibility for ECTs and mentors that started before that year
 - a way to easily query and monitor data so DfE has the information it needs and we can reliably monitor the new services' impact
 - at minimum, the same data that ECF1 supplies to DfE now, to sustain the services' core purposes and monitor its success
+- input to and support guidance around ECF and its services
 
 ## What's in scope after the release of ECF2
 

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -45,10 +45,15 @@ We're hoping later to consider:
 - the creation of a lead provider interface, if we build more evidence it's needed
 - how we notify users such as lead providers of changes to data, for example, if an ECT's name changes
 - more investigation in the best places to get data from for ECTs and mentors
-- 
+- adding or making changes to early career teachers or mentors in bulk
+
 ## What's completely out of scope for ECF2
 
-There's not much we've completely descoped yet, but we might add to this as things come up!
+There's not much we've completely descoped yet, but we might add to this as things come up.
+
+So far, we've decided to descope:
+- sending any updates on personal details to the database for qualified teachers
+
 
 
 

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -1,4 +1,6 @@
-# What's in scope for ECF2
+---
+title: What's in scope for ECF2
+---
 
 We want to improve and rebuild the digital services that facilitate the early career framework (ECF) policy reforms.
 

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -1,6 +1,7 @@
 ---
 title: What's in scope for ECF2
 ---
+## Why we need to define the scope of ECF2
 
 We want to improve and rebuild the digital services that facilitate the early career framework (ECF) policy reforms.
 
@@ -47,9 +48,12 @@ We're hoping later to consider:
 - consolidated registration for schools, so they don't have to register with lead providers, delivery partners or appropriate bodies and DfE separately
 - improving how users that work for multi-academy trusts (MATs) use and access the service
 - the creation of a lead provider interface, if we build more evidence it's needed
+- user permissions for schools, lead providers or appropriate bodies
+- financial information for lead providers to be accessed in the service
 - how we notify users such as lead providers of changes to data, for example, if an ECT's name changes
 - more investigation in the best places to get data from for ECTs and mentors
 - adding or making changes to early career teachers or mentors in bulk
+- if we need to store a preferred name for early career teachers or mentors, different to their legal name stored with their teaching record
 - if we need to store a preferred name for early career teachers or mentors, different to their legal name stored with their teaching record
 
 ## What's completely out of scope for ECF2

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -1,0 +1,55 @@
+# What's in scope for ECF2
+
+We want to improve and rebuild the digital services that facilitate the early career framework (ECF) policy reforms.
+
+However, we can't do all of that at once.
+
+We've detailled what's in scope for our initial minimum viable product release (MVP). This is what functionality or features the service will include when we first make the new services to facilitate ECF go live.
+
+I've also explained what we want to do later, and what is currently entirely out of scope for us.
+
+The objective of setting this out publicly is that we will:
+- be transparent across DfE and wider about what we're aiming to build
+- gather feedback and thoughts on what we're planning to include
+- give clarity to our team of what we need to be focusing on now and what can wait till later
+- use it as a working document to better inform our scope over time
+
+## What's in scope for the initial release of ECF2
+
+This is what we want to design, test and build for the first release of ECF2.
+
+In this initial release, we're planning to include:
+
+- an easier way for schools to register their early career teachers and mentors with DfE, that also helps them understand their ECF responsibilities​
+- an [improved and simplified data model](https://teacher-cpd.design-history.education.gov.uk/ecf-v2/designing-the-database-first/) that better represents reality
+- an easier way for users to access the service, utilising [DfE Sign in](https://github.com/DFE-Digital/ecf2/discussions/43) and allowing multiple accounts per school
+- an API with improved validation rules, surfacing more information lead providers need and simplified where possible
+- improved API documentation, consistent with the NPQ API documentation
+- a way for appropriate bodies to check training data for early career teachers
+- improvements to transfers and changes in early career teacher and mentor records
+- more reliable tracking of changes to data, such as eligibility for funded training
+- joined support and finance tooling for DfE users
+- a way to enable grant funding to be worked out more accurately for mentors
+- payment calculations for lead provider training
+- all changes related to contracts for 2025, and backwards compatibility for ECTs and mentors that started before that year  
+- a way to easily query and monitor data so DfE has the information it needs and we can reliably monitor the new services' impact
+
+
+## What's in scope after the release of ECF2
+
+There's some things we know will help better meet the needs of users for DfE, but we need to leave till later.
+
+We're hoping later to consider:
+- consolidated registration for schools, so they don't have to register with lead providers, delivery partners or appropriate bodies and DfE separately
+- improving how users that work for multi-academy trusts (MATs) use and access the service
+- the creation of a lead provider interface, if we build more evidence it's needed
+- how we notify users such as lead providers of changes to data, for example, if an ECT's name changes
+- more investigation in the best places to get data from for ECTs and mentors
+- 
+## What's completely out of scope for ECF2
+
+There's not much we've completely descoped yet, but we might add to this as things come up!
+
+
+
+

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -11,6 +11,7 @@ We've detailled what's in scope for our initial minimum viable product release (
 I've also explained what we want to do later, and what is currently entirely out of scope for us.
 
 The objective of setting this out publicly is that we will:
+
 - be transparent across DfE and wider about what we're aiming to build
 - gather feedback and thoughts on what we're planning to include
 - give clarity to our team of what we need to be focusing on now and what can wait till later
@@ -33,15 +34,15 @@ In this initial release, we're planning to include:
 - joined support and finance tooling for DfE users
 - a way to enable grant funding to be worked out more accurately for mentors
 - payment calculations for lead provider training
-- all changes related to contracts for 2025, and backwards compatibility for ECTs and mentors that started before that year  
+- all changes related to contracts for 2025, and backwards compatibility for ECTs and mentors that started before that year
 - a way to easily query and monitor data so DfE has the information it needs and we can reliably monitor the new services' impact
-
 
 ## What's in scope after the release of ECF2
 
 There's some things we know will help better meet the needs of users for DfE, but we need to leave till later.
 
 We're hoping later to consider:
+
 - consolidated registration for schools, so they don't have to register with lead providers, delivery partners or appropriate bodies and DfE separately
 - improving how users that work for multi-academy trusts (MATs) use and access the service
 - the creation of a lead provider interface, if we build more evidence it's needed
@@ -55,8 +56,3 @@ There's not much we've completely descoped yet, but we might add to this as thin
 
 So far, we've decided to descope:
 - sending any updates on personal details to the database for qualified teachers
-
-
-
-
-

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -54,8 +54,6 @@ We're hoping later to consider:
 - more investigation in the best places to get data from for ECTs and mentors
 - adding or making changes to early career teachers or mentors in bulk
 - if we need to store a preferred name for early career teachers or mentors, different to their legal name stored with their teaching record
-- if we need to store a preferred name for early career teachers or mentors, different to their legal name stored with their teaching record
-- if we need to store a preferred name for early career teachers or mentors, different to their legal name stored with their teaching record
 
 ## What's completely out of scope for ECF2
 

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -36,6 +36,7 @@ In this initial release, we're planning to include:
 - payment calculations for lead provider training
 - all changes related to contracts for 2025, and backwards compatibility for ECTs and mentors that started before that year
 - a way to easily query and monitor data so DfE has the information it needs and we can reliably monitor the new services' impact
+- at minimum, the same data that ECF1 supplies to DfE now, to sustain the services' core purposes and monitor its success
 
 ## What's in scope after the release of ECF2
 

--- a/documentation/site/content/product/scope.md
+++ b/documentation/site/content/product/scope.md
@@ -50,6 +50,7 @@ We're hoping later to consider:
 - how we notify users such as lead providers of changes to data, for example, if an ECT's name changes
 - more investigation in the best places to get data from for ECTs and mentors
 - adding or making changes to early career teachers or mentors in bulk
+- if we need to store a preferred name for early career teachers or mentors, different to their legal name stored with their teaching record
 
 ## What's completely out of scope for ECF2
 


### PR DESCRIPTION
In this PR I've attempted to:
- Create a product docs folder
- Add the first page in this folder, on what's in and out of scope for ECF2