### PR TITLE
Initial data model and GIAS import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :development, :test do
   gem "rspec"
   gem "rspec-rails"
   gem "rubocop-govuk"
+  gem "shoulda-matchers"
 end
 
 group :nanoc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,6 +390,8 @@ GEM
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
     set (1.1.0)
+    shoulda-matchers (6.4.0)
+      activesupport (>= 5.2.0)
     slow_enumerator_tools (1.1.0)
     solid_queue (0.7.1)
       activejob (>= 7.1)
@@ -456,6 +458,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop-govuk
+  shoulda-matchers
   solid_queue
   tzinfo-data
 

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -1,3 +1,15 @@
 class AcademicYear < ApplicationRecord
-  has_many :provider_partnerships
+  ECF_FIRST_YEAR = 2020
+
+  # Associations
+  has_many :provider_partnerships, inverse_of: :academic_year
+
+  # Validations
+  validates :year,
+            presence: true,
+            uniqueness: true,
+            numericality: {
+              only_integer: true,
+              greater_than_or_equal_to: ECF_FIRST_YEAR,
+            }
 end

--- a/app/models/academic_year.rb
+++ b/app/models/academic_year.rb
@@ -1,0 +1,3 @@
+class AcademicYear < ApplicationRecord
+  has_many :provider_partnerships
+end

--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -1,0 +1,3 @@
+class AppropriateBody < ApplicationRecord
+  has_many :induction_periods
+end

--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -1,3 +1,9 @@
 class AppropriateBody < ApplicationRecord
-  has_many :induction_periods
+  # Associations
+  has_many :induction_periods, inverse_of: :appropriate_body
+
+  # Validations
+  validates :name,
+            presence: true,
+            uniqueness: true
 end

--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -1,0 +1,25 @@
+module Interval
+  extend ActiveSupport::Concern
+
+  included do
+    # Validations
+    validate :period_dates_validation
+
+    # Scopes
+    scope :extending_later_than, ->(date) { where("finished_on IS NULL OR finished_on > ?", date) }
+    scope :starting_earlier_than, ->(date) { where("started_on < ?", date) }
+  end
+
+  def period_dates_validation
+    return if [started_on, finished_on].any?(&:blank?)
+
+    errors.add(:finished_on, "Must be later than :started_on") if finished_on <= started_on
+  end
+
+  class_methods do
+    def overlapping(start_date, end_date)
+      scope = extending_later_than(start_date)
+      end_date ? scope.starting_earlier_than(end_date) : scope
+    end
+  end
+end

--- a/app/models/declaration.rb
+++ b/app/models/declaration.rb
@@ -1,0 +1,3 @@
+class Declaration < ApplicationRecord
+  belongs_to :training_period
+end

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -1,3 +1,9 @@
 class DeliveryPartner < ApplicationRecord
-  has_many :object
+  # Associations
+  has_many :provider_partnerships, inverse_of: :delivery_partner
+
+  # Validations
+  validates :name,
+            presence: true,
+            uniqueness: true
 end

--- a/app/models/delivery_partner.rb
+++ b/app/models/delivery_partner.rb
@@ -1,0 +1,3 @@
+class DeliveryPartner < ApplicationRecord
+  has_many :object
+end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -1,6 +1,48 @@
 class ECTAtSchoolPeriod < ApplicationRecord
-  has_many :induction_periods
-  has_many :mentorship_periods
-  belongs_to :school
-  belongs_to :teacher
+  include Interval
+
+  # Associations
+  belongs_to :school, inverse_of: :ect_at_school_periods
+  belongs_to :teacher, inverse_of: :ect_at_school_periods
+  has_many :induction_periods, inverse_of: :ect_at_school_period
+  has_many :mentorship_periods, inverse_of: :mentee
+  has_many :training_periods, as: :trainee
+
+  # Validations
+  validates :finished_on,
+            uniqueness: { scope: :teacher_id,
+                          allow_nil: true }
+
+  validates :started_on,
+            presence: true,
+            uniqueness: { scope: :teacher_id }
+
+  validates :school_id,
+            presence: true
+
+  validates :teacher_id,
+            presence: true
+
+  validate :school_presence
+  validate :teacher_distinct_period
+  validate :teacher_presence
+
+  # Scopes
+  scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
+  scope :siblings_of, ->(instance) { for_teacher(instance.teacher_id).where.not(id: instance.id) }
+
+private
+
+  def school_presence
+    errors.add(:school_id, "School does not exist") if school.nil?
+  end
+
+  def teacher_distinct_period
+    overlapping_siblings = self.class.siblings_of(self).overlapping(started_on, finished_on).exists?
+    errors.add(:base, "Teacher ECT periods cannot overlap") if overlapping_siblings
+  end
+
+  def teacher_presence
+    errors.add(:teacher_id, "Teacher does not exist") if teacher.nil?
+  end
 end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -23,9 +23,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   validates :teacher_id,
             presence: true
 
-  validate :school_presence
   validate :teacher_distinct_period
-  validate :teacher_presence
 
   # Scopes
   scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
@@ -33,16 +31,8 @@ class ECTAtSchoolPeriod < ApplicationRecord
 
 private
 
-  def school_presence
-    errors.add(:school_id, "School does not exist") if school.nil?
-  end
-
   def teacher_distinct_period
     overlapping_siblings = self.class.siblings_of(self).overlapping(started_on, finished_on).exists?
     errors.add(:base, "Teacher ECT periods cannot overlap") if overlapping_siblings
-  end
-
-  def teacher_presence
-    errors.add(:teacher_id, "Teacher does not exist") if teacher.nil?
   end
 end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -1,0 +1,6 @@
+class ECTAtSchoolPeriod < ApplicationRecord
+  has_many :induction_periods
+  has_many :mentorship_periods
+  belongs_to :school
+  belongs_to :teacher
+end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -6,7 +6,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
   belongs_to :teacher, inverse_of: :ect_at_school_periods
   has_many :induction_periods, inverse_of: :ect_at_school_period
   has_many :mentorship_periods, inverse_of: :mentee
-  has_many :training_periods, as: :trainee
+  has_many :training_periods, inverse_of: :ect_at_school_period
 
   # Validations
   validates :finished_on,

--- a/app/models/gias/school.rb
+++ b/app/models/gias/school.rb
@@ -1,3 +1,5 @@
 class GIAS::School < ApplicationRecord
+  self.table_name = "gias_schools"
+
   has_one :counterpart, class_name: "::School", foreign_key: :urn
 end

--- a/app/models/gias/school.rb
+++ b/app/models/gias/school.rb
@@ -1,0 +1,3 @@
+class GIAS::School < ApplicationRecord
+  has_one :counterpart, class_name: "::School", foreign_key: :urn
+end

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -1,0 +1,5 @@
+class InductionPeriod < ApplicationRecord
+  belongs_to :appropriate_body
+  belongs_to :ect_at_school_period
+  has_many :training_periods
+end

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -22,8 +22,6 @@ class InductionPeriod < ApplicationRecord
   validates :ect_at_school_period_id,
             presence: true
 
-  validate :appropriate_body_presence
-  validate :ect_at_school_period_presence
   validate :teacher_distinct_period
 
   # Scopes
@@ -32,14 +30,6 @@ class InductionPeriod < ApplicationRecord
   scope :siblings_of, ->(instance) { for_ect(instance.ect_at_school_period_id).where.not(id: instance.id) }
 
 private
-
-  def appropriate_body_presence
-    errors.add(:appropriate_body_id, "Appropriate body not registered") if appropriate_body.nil?
-  end
-
-  def ect_at_school_period_presence
-    errors.add(:ect_at_school_period_id, "ECT period not registered") if ect_at_school_period.nil?
-  end
 
   def teacher_distinct_period
     overlapping_siblings = self.class.siblings_of(self).overlapping(started_on, finished_on).exists?

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -1,5 +1,48 @@
 class InductionPeriod < ApplicationRecord
+  include Interval
+
+  # Associations
   belongs_to :appropriate_body
-  belongs_to :ect_at_school_period
-  has_many :training_periods
+  belongs_to :ect_at_school_period, class_name: "ECTAtSchoolPeriod", inverse_of: :induction_periods
+
+  # Validations
+  validates :finished_on,
+            uniqueness: { scope: :ect_at_school_period_id,
+                          message: "matches the end date of an existing period for ECT",
+                          allow_nil: true }
+
+  validates :started_on,
+            presence: true,
+            uniqueness: { scope: :ect_at_school_period_id,
+                          message: "matches the start date of an existing period for ECT" }
+
+  validates :appropriate_body_id,
+            presence: true
+
+  validates :ect_at_school_period_id,
+            presence: true
+
+  validate :appropriate_body_presence
+  validate :ect_at_school_period_presence
+  validate :teacher_distinct_period
+
+  # Scopes
+  scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
+  scope :for_appropriate_body, ->(appropriate_body_id) { where(appropriate_body_id:) }
+  scope :siblings_of, ->(instance) { for_ect(instance.ect_at_school_period_id).where.not(id: instance.id) }
+
+private
+
+  def appropriate_body_presence
+    errors.add(:appropriate_body_id, "Appropriate body not registered") if appropriate_body.nil?
+  end
+
+  def ect_at_school_period_presence
+    errors.add(:ect_at_school_period_id, "ECT period not registered") if ect_at_school_period.nil?
+  end
+
+  def teacher_distinct_period
+    overlapping_siblings = self.class.siblings_of(self).overlapping(started_on, finished_on).exists?
+    errors.add(:base, "Teacher induction periods cannot overlap") if overlapping_siblings
+  end
 end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -1,3 +1,9 @@
 class LeadProvider < ApplicationRecord
-  has_many :provider_partnerships
+  # Associations
+  has_many :provider_partnerships, inverse_of: :lead_provider
+
+  # Validations
+  validates :name,
+            presence: true,
+            uniqueness: true
 end

--- a/app/models/lead_provider.rb
+++ b/app/models/lead_provider.rb
@@ -1,0 +1,3 @@
+class LeadProvider < ApplicationRecord
+  has_many :provider_partnerships
+end

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -24,9 +24,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
   validates :teacher_id,
             presence: true
 
-  validate :school_presence
   validate :teacher_school_distinct_period
-  validate :teacher_presence
 
   # Scopes
   scope :for_school, ->(school_id) { where(school_id:) }
@@ -36,10 +34,6 @@ class MentorAtSchoolPeriod < ApplicationRecord
 
 private
 
-  def school_presence
-    errors.add(:school_id, "School does not exist") if school.nil?
-  end
-
   def siblings
     self.class.where(teacher_id:).where.not(id:)
   end
@@ -47,9 +41,5 @@ private
   def teacher_school_distinct_period
     overlapping_siblings = self.class.school_siblings_of(self).overlapping(started_on, finished_on).exists?
     errors.add(:base, "Teacher School ECT periods cannot overlap") if overlapping_siblings
-  end
-
-  def teacher_presence
-    errors.add(:teacher_id, "Teacher does not exist") if teacher.nil?
   end
 end

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -5,7 +5,7 @@ class MentorAtSchoolPeriod < ApplicationRecord
   belongs_to :school, inverse_of: :mentor_at_school_periods
   belongs_to :teacher, inverse_of: :mentor_at_school_periods
   has_many :mentorship_periods, inverse_of: :mentor
-  has_many :training_periods, as: :trainee
+  has_many :training_periods, inverse_of: :mentor_at_school_period
 
   # Validations
   validates :finished_on,

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -1,0 +1,6 @@
+class MentorAtSchoolPeriod < ApplicationRecord
+  has_many :mentorship_periods
+  has_many :training_periods
+  belongs_to :school
+  belongs_to :teacher
+end

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -1,6 +1,55 @@
 class MentorAtSchoolPeriod < ApplicationRecord
-  has_many :mentorship_periods
-  has_many :training_periods
-  belongs_to :school
-  belongs_to :teacher
+  include Interval
+
+  # Associations
+  belongs_to :school, inverse_of: :mentor_at_school_periods
+  belongs_to :teacher, inverse_of: :mentor_at_school_periods
+  has_many :mentorship_periods, inverse_of: :mentor
+  has_many :training_periods, as: :trainee
+
+  # Validations
+  validates :finished_on,
+            uniqueness: { scope: %i[teacher_id school_id],
+                          message: "matches the end date of an existing period",
+                          allow_nil: true }
+
+  validates :started_on,
+            presence: true,
+            uniqueness: { scope: %i[teacher_id school_id],
+                          message: "matches the start date of an existing period" }
+
+  validates :school_id,
+            presence: true
+
+  validates :teacher_id,
+            presence: true
+
+  validate :school_presence
+  validate :teacher_school_distinct_period
+  validate :teacher_presence
+
+  # Scopes
+  scope :for_school, ->(school_id) { where(school_id:) }
+  scope :for_teacher, ->(teacher_id) { where(teacher_id:) }
+  scope :siblings_of, ->(instance) { for_teacher(instance.teacher_id).where.not(id: instance.id) }
+  scope :school_siblings_of, ->(instance) { siblings_of(instance).for_school(instance.school_id) }
+
+private
+
+  def school_presence
+    errors.add(:school_id, "School does not exist") if school.nil?
+  end
+
+  def siblings
+    self.class.where(teacher_id:).where.not(id:)
+  end
+
+  def teacher_school_distinct_period
+    overlapping_siblings = self.class.school_siblings_of(self).overlapping(started_on, finished_on).exists?
+    errors.add(:base, "Teacher School ECT periods cannot overlap") if overlapping_siblings
+  end
+
+  def teacher_presence
+    errors.add(:teacher_id, "Teacher does not exist") if teacher.nil?
+  end
 end

--- a/app/models/mentorship_period.rb
+++ b/app/models/mentorship_period.rb
@@ -29,8 +29,6 @@ class MentorshipPeriod < ApplicationRecord
   validates :mentor_at_school_period_id,
             presence: true
 
-  validate :mentee_presence
-  validate :mentor_presence
   validate :mentee_distinct_period
 
   # Scopes
@@ -39,14 +37,6 @@ class MentorshipPeriod < ApplicationRecord
   scope :mentee_siblings_of, ->(instance) { for_mentee(instance.ect_at_school_period_id).where.not(id: instance.id) }
 
 private
-
-  def mentee_presence
-    errors.add(:ect_at_school_period_id, "Mentee does not exist") if mentee.nil?
-  end
-
-  def mentor_presence
-    errors.add(:mentor_at_school_period_id, "Mentor does not exist") if mentor.nil?
-  end
 
   def mentee_distinct_period
     overlapping_siblings = self.class.mentee_siblings_of(self).overlapping(started_on, finished_on).exists?

--- a/app/models/mentorship_period.rb
+++ b/app/models/mentorship_period.rb
@@ -1,0 +1,8 @@
+class MentorshipPeriod < ApplicationRecord
+  belongs_to :mentee,
+    class_name: "ECTAtSchoolPeriod",
+    foreign_key: "ect_at_school_period_id"
+  belongs_to :mentor,
+    class_name: "MentorAtSchoolPeriod",
+    foreign_key: "mentor_at_school_period_id"
+end

--- a/app/models/mentorship_period.rb
+++ b/app/models/mentorship_period.rb
@@ -1,8 +1,55 @@
 class MentorshipPeriod < ApplicationRecord
+  include Interval
+
+  # Associations
   belongs_to :mentee,
              class_name: "ECTAtSchoolPeriod",
-             foreign_key: "ect_at_school_period_id"
+             foreign_key: :ect_at_school_period_id,
+             inverse_of: :mentorship_periods
+
   belongs_to :mentor,
              class_name: "MentorAtSchoolPeriod",
-             foreign_key: "mentor_at_school_period_id"
+             foreign_key: :mentor_at_school_period_id,
+             inverse_of: :mentorship_periods
+
+  # Validations
+  validates :finished_on,
+            uniqueness: { scope: :ect_at_school_period_id,
+                          message: "matches the end date of an existing period for mentee",
+                          allow_nil: true }
+
+  validates :started_on,
+            presence: true,
+            uniqueness: { scope: :ect_at_school_period_id,
+                          message: "matches the start date of an existing period for mentee" }
+
+  validates :ect_at_school_period_id,
+            presence: true
+
+  validates :mentor_at_school_period_id,
+            presence: true
+
+  validate :mentee_presence
+  validate :mentor_presence
+  validate :mentee_distinct_period
+
+  # Scopes
+  scope :for_mentee, ->(id) { where(ect_at_school_period_id: id) }
+  scope :for_mentor, ->(id) { where(mentor_at_school_period_id: id) }
+  scope :mentee_siblings_of, ->(instance) { for_mentee(instance.ect_at_school_period_id).where.not(id: instance.id) }
+
+private
+
+  def mentee_presence
+    errors.add(:ect_at_school_period_id, "Mentee does not exist") if mentee.nil?
+  end
+
+  def mentor_presence
+    errors.add(:mentor_at_school_period_id, "Mentor does not exist") if mentor.nil?
+  end
+
+  def mentee_distinct_period
+    overlapping_siblings = self.class.mentee_siblings_of(self).overlapping(started_on, finished_on).exists?
+    errors.add(:base, "Mentee periods cannot overlap") if overlapping_siblings
+  end
 end

--- a/app/models/mentorship_period.rb
+++ b/app/models/mentorship_period.rb
@@ -1,8 +1,8 @@
 class MentorshipPeriod < ApplicationRecord
   belongs_to :mentee,
-    class_name: "ECTAtSchoolPeriod",
-    foreign_key: "ect_at_school_period_id"
+             class_name: "ECTAtSchoolPeriod",
+             foreign_key: "ect_at_school_period_id"
   belongs_to :mentor,
-    class_name: "MentorAtSchoolPeriod",
-    foreign_key: "mentor_at_school_period_id"
+             class_name: "MentorAtSchoolPeriod",
+             foreign_key: "mentor_at_school_period_id"
 end

--- a/app/models/provider_partnership.rb
+++ b/app/models/provider_partnership.rb
@@ -16,26 +16,8 @@ class ProviderPartnership < ApplicationRecord
   validates :delivery_partner_id,
             presence: true
 
-  validate :academic_year_presence
-  validate :lead_provider_presence
-  validate :delivery_partner_presence
-
   # Scopes
   scope :for_academic_year, ->(year) { where(academic_year_id: year) }
   scope :for_lead_provider, ->(lead_provider_id) { where(lead_provider_id:) }
   scope :for_delivery_partner, ->(delivery_partner_id) { where(delivery_partner_id:) }
-
-private
-
-  def academic_year_presence
-    errors.add(:academic_year_id, "Academic year not registered") if academic_year.nil?
-  end
-
-  def delivery_partner_presence
-    errors.add(:delivery_partner_id, "Delivery partner not registered") if delivery_partner.nil?
-  end
-
-  def lead_provider_presence
-    errors.add(:lead_provider_id, "Lead provider not registered") if lead_provider.nil?
-  end
 end

--- a/app/models/provider_partnership.rb
+++ b/app/models/provider_partnership.rb
@@ -1,5 +1,41 @@
 class ProviderPartnership < ApplicationRecord
-  belongs_to :academic_year
-  belongs_to :lead_provider
-  belongs_to :delivery_partner
+  # Associations
+  belongs_to :academic_year, inverse_of: :provider_partnerships
+  belongs_to :lead_provider, inverse_of: :provider_partnerships
+  belongs_to :delivery_partner, inverse_of: :provider_partnerships
+
+  # Validations
+  validates :academic_year_id,
+            presence: true,
+            uniqueness: { scope: %i[lead_provider_id delivery_partner_id],
+                          message: "has already been added" }
+
+  validates :lead_provider_id,
+            presence: true
+
+  validates :delivery_partner_id,
+            presence: true
+
+  validate :academic_year_presence
+  validate :lead_provider_presence
+  validate :delivery_partner_presence
+
+  # Scopes
+  scope :for_academic_year, ->(year) { where(academic_year_id: year) }
+  scope :for_lead_provider, ->(lead_provider_id) { where(lead_provider_id:) }
+  scope :for_delivery_partner, ->(delivery_partner_id) { where(delivery_partner_id:) }
+
+private
+
+  def academic_year_presence
+    errors.add(:academic_year_id, "Academic year not registered") if academic_year.nil?
+  end
+
+  def delivery_partner_presence
+    errors.add(:delivery_partner_id, "Delivery partner not registered") if delivery_partner.nil?
+  end
+
+  def lead_provider_presence
+    errors.add(:lead_provider_id, "Lead provider not registered") if lead_provider.nil?
+  end
 end

--- a/app/models/provider_partnership.rb
+++ b/app/models/provider_partnership.rb
@@ -1,0 +1,5 @@
+class ProviderPartnership < ApplicationRecord
+  belongs_to :academic_year
+  belongs_to :lead_provider
+  belongs_to :delivery_partner
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,0 +1,8 @@
+class School < ApplicationRecord
+  has_many :ect_at_schools
+  belongs_to :gias_school, class_name: "GIAS::School", foreign_key: :urn
+
+  def to_param
+    urn
+  end
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,7 +1,19 @@
 class School < ApplicationRecord
-  has_many :ect_at_schools
+  # Associations
   belongs_to :gias_school, class_name: "GIAS::School", foreign_key: :urn
+  has_many :ect_at_school_periods, inverse_of: :school
+  has_many :mentor_at_school_periods, inverse_of: :school
 
+  # Validations
+  validates :name,
+            presence: true,
+            uniqueness: { case_sensitive: false }
+
+  validates :urn,
+            presence: true,
+            uniqueness: true
+
+  # Instance Methods
   def to_param
     urn
   end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,0 +1,4 @@
+class Teacher < ApplicationRecord
+  has_many :ect_at_school_periods
+  has_many :mentor_at_school_periods
+end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,4 +1,9 @@
 class Teacher < ApplicationRecord
-  has_many :ect_at_school_periods
-  has_many :mentor_at_school_periods
+  # Associations
+  has_many :ect_at_school_periods, inverse_of: :teacher
+  has_many :mentor_at_school_periods, inverse_of: :teacher
+
+  # Validations
+  validates :name,
+            presence: true
 end

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -1,0 +1,6 @@
+class TrainingPeriod < ApplicationRecord
+  belongs_to :provider_partnership
+  belongs_to :induction_period, optional: true
+  belongs_to :mentor_at_school, optional: true
+  has_many :declarations
+end

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -2,38 +2,56 @@ class TrainingPeriod < ApplicationRecord
   include Interval
 
   # Associations
-  belongs_to :trainee, polymorphic: true, inverse_of: :training_periods
+  belongs_to :ect_at_school_period, class_name: "ECTAtSchoolPeriod", inverse_of: :training_periods
+  belongs_to :mentor_at_school_period, inverse_of: :training_periods
   belongs_to :provider_partnership
   has_many :declarations, inverse_of: :training_period
 
   # Validations
   validates :finished_on,
-            uniqueness: { scope: %i[trainee_id trainee_type],
+            uniqueness: { scope: %i[ect_at_school_period_id mentor_at_school_period_id],
                           message: "matches the end date of an existing period for trainee",
                           allow_nil: true }
 
   validates :started_on,
             presence: true,
-            uniqueness: { scope: %i[trainee_id trainee_type],
+            uniqueness: { scope: %i[ect_at_school_period_id mentor_at_school_period_id],
                           message: "matches the start date of an existing period for trainee" }
-
-  validates :trainee_id,
-            presence: true
-
-  validates :trainee_type,
-            presence: true
 
   validates :provider_partnership_id,
             presence: true
 
+  validate :one_id_of_trainee_present
   validate :trainee_distinct_period
 
   # Scopes
-  scope :for_trainee, ->(trainee_id, trainee_type) { where(trainee_id:, trainee_type:) }
+  scope :for_ect, ->(ect_at_school_period_id) { where(ect_at_school_period_id:) }
+  scope :for_mentor, ->(mentor_at_school_period_id) { where(mentor_at_school_period_id:) }
   scope :for_provider_partnership, ->(provider_partnership_id) { where(provider_partnership_id:) }
-  scope :trainee_siblings_of, ->(instance) { for_trainee(instance.trainee_id, instance.trainee_type).where.not(id: instance.id) }
+  scope :ect_siblings_of, ->(instance) { for_ect(instance.ect_at_school_period_id).where.not(id: instance.id) }
+  scope :mentor_siblings_of, ->(instance) { for_mentor(instance.mentor_at_school_period_id).where.not(id: instance.id) }
+
+  def self.trainee_siblings_of(instance)
+    scope = where.not(id: instance.id)
+    instance.for_ect? ? scope.ect_siblings_of(instance) : scope.mentor_siblings_of(instance)
+  end
+
+  # Instance methods
+  def for_ect?
+    ect_at_school_period_id.present?
+  end
+
+  def for_mentor?
+    mentor_at_school_period_id.present?
+  end
 
 private
+
+  def one_id_of_trainee_present
+    ids = [ect_at_school_period_id, mentor_at_school_period_id]
+    errors.add(:base, "Id of trainee missing") if ids.none?
+    errors.add(:base, "Only one id of trainee required. Two given") if ids.all?
+  end
 
   def trainee_distinct_period
     overlapping_siblings = self.class.trainee_siblings_of(self).overlapping(started_on, finished_on).exists?

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -1,6 +1,52 @@
 class TrainingPeriod < ApplicationRecord
+  include Interval
+
+  # Associations
+  belongs_to :trainee, polymorphic: true, inverse_of: :training_periods
   belongs_to :provider_partnership
-  belongs_to :induction_period, optional: true
-  belongs_to :mentor_at_school, optional: true
-  has_many :declarations
+  has_many :declarations, inverse_of: :training_period
+
+  # Validations
+  validates :finished_on,
+            uniqueness: { scope: %i[trainee_id trainee_type],
+                          message: "matches the end date of an existing period for trainee",
+                          allow_nil: true }
+
+  validates :started_on,
+            presence: true,
+            uniqueness: { scope: %i[trainee_id trainee_type],
+                          message: "matches the start date of an existing period for trainee" }
+
+  validates :trainee_id,
+            presence: true
+
+  validates :trainee_type,
+            presence: true
+
+  validates :provider_partnership_id,
+            presence: true
+
+  validate :trainee_presence
+  validate :provider_partnership_presence
+  validate :trainee_distinct_period
+
+  # Scopes
+  scope :for_trainee, ->(trainee_id, trainee_type) { where(trainee_id:, trainee_type:) }
+  scope :for_provider_partnership, ->(provider_partnership_id) { where(provider_partnership_id:) }
+  scope :trainee_siblings_of, ->(instance) { for_trainee(instance.trainee_id, instance.trainee_type).where.not(id: instance.id) }
+
+private
+
+  def trainee_presence
+    errors.add(:trainee_id, "Trainee not registered") if trainee.nil?
+  end
+
+  def provider_partnership_presence
+    errors.add(:provider_partnership_id, "Provider partnership not registered") if provider_partnership.nil?
+  end
+
+  def trainee_distinct_period
+    overlapping_siblings = self.class.trainee_siblings_of(self).overlapping(started_on, finished_on).exists?
+    errors.add(:base, "Trainee periods cannot overlap") if overlapping_siblings
+  end
 end

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -26,8 +26,6 @@ class TrainingPeriod < ApplicationRecord
   validates :provider_partnership_id,
             presence: true
 
-  validate :trainee_presence
-  validate :provider_partnership_presence
   validate :trainee_distinct_period
 
   # Scopes
@@ -36,14 +34,6 @@ class TrainingPeriod < ApplicationRecord
   scope :trainee_siblings_of, ->(instance) { for_trainee(instance.trainee_id, instance.trainee_type).where.not(id: instance.id) }
 
 private
-
-  def trainee_presence
-    errors.add(:trainee_id, "Trainee not registered") if trainee.nil?
-  end
-
-  def provider_partnership_presence
-    errors.add(:provider_partnership_id, "Provider partnership not registered") if provider_partnership.nil?
-  end
 
   def trainee_distinct_period
     overlapping_siblings = self.class.trainee_siblings_of(self).overlapping(started_on, finished_on).exists?

--- a/app/services/gias/schools/import.rb
+++ b/app/services/gias/schools/import.rb
@@ -1,0 +1,49 @@
+class GIAS::Schools::Import
+  def initialize(urn:, name:, local_authority:, phase:, establishment_type:, school_status:, administrative_district:, address_line1:, address_line2:, address_line3:, postcode:, primary_contact_email:, secondary_contact_email:, section_41_approved:, opened_on:, closed_on:)
+    @school = GIAS::School.new(
+      urn:,
+      name:,
+      local_authority:,
+      phase:,
+      establishment_type:,
+      school_status:,
+      administrative_district:,
+      address_line1:,
+      address_line2:,
+      address_line3:,
+      postcode:,
+      primary_contact_email:,
+      secondary_contact_email:,
+      section_41_approved:,
+      opened_on:,
+      closed_on:
+    )
+  end
+
+  def self.import_from_csv_row(row)
+    new(
+      urn: row["URN"],
+      name: row["EstablishmentName"],
+      local_authority: row["LA (name)"],
+      phase: row["PhaseOfEducation (name)"],
+      establishment_type: row["TypeOfEstablishment (name)"],
+      school_status: row["EstablishmentStatus (name)"].underscore.parameterize(separator: "_").sub("open_but_", ""),
+      administrative_district: row["DistrictAdministrative (name)"],
+      address_line1: row["Street"],
+      address_line2: row["Locality"].presence,
+      address_line3: row["Town"].presence,
+      postcode: row["Postcode"],
+      primary_contact_email: row["MainEmail"].presence,
+      secondary_contact_email: row["AlternativeEmail"].presence,
+      section_41_approved: row["Section41Approved (name)"] == "Approved",
+      opened_on: row["OpenDate"],
+      closed_on: row["CloseDate"]
+    ).save!
+  end
+
+  def save!
+    @school.save!
+  end
+end
+
+# SchoolCSV.each { |row| Schools::Import.import_from_csv_row(row) }

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,4 +14,5 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "ECT"
   inflect.acronym "API"
+  inflect.acronym "GIAS"
 end

--- a/db/migrate/20240830140640_import_tables.rb
+++ b/db/migrate/20240830140640_import_tables.rb
@@ -35,8 +35,8 @@ class ImportTables < ActiveRecord::Migration[7.2]
     create_table :gias_schools, primary_key: :urn do |t|
       t.string :name, null: false
       t.integer :local_authority
-      t.string :school_phase
-      t.string :school_type
+      t.string :phase
+      t.string :establishment_type
 
       t.enum :school_status, default: "open", null: false, enum_type: :gias_school_statuses
 

--- a/db/migrate/20240830140640_import_tables.rb
+++ b/db/migrate/20240830140640_import_tables.rb
@@ -1,36 +1,38 @@
 class ImportTables < ActiveRecord::Migration[7.2]
   def change
-    create_table :academic_years do |t|
-      t.integer :year, null: false
+    create_table :academic_years, id: false do |t|
+      t.integer :year, primary_key: true, null: false, index: { unique: true }
 
       t.timestamps
     end
 
     create_table :lead_providers do |t|
-      t.string :name
+      t.string :name, null: false, index: { unique: true }
 
       t.timestamps
     end
 
     create_table :delivery_partners do |t|
-      t.string :name
+      t.string :name, null: false, index: { unique: true }
 
       t.timestamps
     end
 
     create_table :teachers do |t|
-      t.string :name
+      t.string :name, null: false, index: true
 
       t.timestamps
     end
 
     create_table :appropriate_bodies do |t|
-      t.string :name
+      t.string :name, null: false, index: { unique: true }
 
       t.timestamps
     end
 
     create_enum :gias_school_statuses, %w[open closed proposed_to_close proposed_to_open]
+    create_enum :induction_eligibility_status, %w[eligible ineligible]
+    create_enum :funding_eligibility_status, %w[eligible_for_fip eligible_for_cip ineligible]
 
     create_table :gias_schools, primary_key: :urn do |t|
       t.string :name, null: false
@@ -39,6 +41,8 @@ class ImportTables < ActiveRecord::Migration[7.2]
       t.string :establishment_type
 
       t.enum :school_status, default: "open", null: false, enum_type: :gias_school_statuses
+      t.enum :induction_eligibility, null: false, enum_type: :induction_eligibility_status
+      t.enum :funding_eligibility, null: false, enum_type: :funding_eligibility_status
 
       t.string :administrative_district
 
@@ -56,79 +60,96 @@ class ImportTables < ActiveRecord::Migration[7.2]
       t.timestamps
     end
 
-    create_enum :induction_eligibility_status, %w[eligible ineligible]
-    create_enum :funding_eligibility_status, %w[eligible_for_fip eligible_for_cip ineligible]
-
     create_table :schools do |t|
       t.integer :urn, null: false, index: { unique: true, name: "schools_unique_urn" }
-      t.enum :induction_eligibility, null: false, enum_type: :induction_eligibility_status
-      t.enum :funding_eligibility, null: false, enum_type: :funding_eligibility_status
+      t.string :name, null: false, index: { unique: true }
 
       t.timestamps
     end
 
     create_table :ect_at_school_periods do |t|
-      t.references :school
-      t.references :teacher
+      t.references :school, null: false, foreign_key: true
+      t.references :teacher, null: false, foreign_key: true
+
       t.date :started_on, null: false
       t.date :finished_on
-      t.index "school_id, teacher_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+
+      t.index "teacher_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+      t.index "school_id, teacher_id, started_on", unique: true
+      t.index "teacher_id, started_on", unique: true
 
       t.timestamps
     end
 
     create_table :mentor_at_school_periods do |t|
-      t.references :school
-      t.references :teacher
+      t.references :school, null: false, foreign_key: true
+      t.references :teacher, null: false, foreign_key: true
+
       t.date :started_on, null: false
       t.date :finished_on
+
       t.index "school_id, teacher_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+      t.index "school_id, teacher_id, started_on", unique: true
+      t.index "teacher_id, started_on", unique: true
 
       t.timestamps
     end
 
     create_table :mentorship_periods do |t|
-      t.references :ect_at_school_period
-      t.references :mentor_at_school_period
+      t.references :ect_at_school_period, null: false, foreign_key: true
+      t.references :mentor_at_school_period, null: false, foreign_key: true
+
       t.date :started_on, null: false
       t.date :finished_on
-      t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+
+      t.index "ect_at_school_period_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+      t.index "ect_at_school_period_id, started_on", unique: true
+      t.index "mentor_at_school_period_id, ect_at_school_period_id, started_on", unique: true
 
       t.timestamps
     end
 
     create_table :provider_partnerships do |t|
-      t.references :academic_year
-      t.references :lead_provider
-      t.references :delivery_partner
+      t.references :academic_year, null: false, foreign_key: { primary_key: :year }
+      t.references :lead_provider, null: false, foreign_key: true
+      t.references :delivery_partner, null: false, foreign_key: true
+
+      t.index "academic_year_id, lead_provider_id, delivery_partner_id", unique: true, name: "yearly_unique_provider_partnerships"
 
       t.timestamps
     end
 
     create_table :training_periods do |t|
-      t.references :provider_partnership
-      t.references :ect_at_school_period
-      t.references :mentor_at_school_period
+      t.references :provider_partnership, null: false, foreign_key: true
+      t.references :trainee, null: false, polymorphic: true
+
       t.date :started_on, null: false
       t.date :finished_on
-      t.index "ect_at_school_period_id, mentor_at_school_period_id, provider_partnership_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+
+      t.index "trainee_id, trainee_type, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+      t.index "trainee_id, trainee_type, started_on", unique: true
+      t.index "provider_partnership_id, trainee_id, trainee_type, started_on", unique: true, name: "provider_partnership_trainings"
 
       t.timestamps
     end
 
     create_table :declarations do |t|
       t.references :training_period
+
       t.string :declaration_type
 
       t.timestamps
     end
 
     create_table :induction_periods do |t|
-      t.references :ect_at_school_period
-      t.references :appropriate_body
+      t.references :appropriate_body, null: false, foreign_key: true
+      t.references :ect_at_school_period, null: false, foreign_key: true
+
       t.date :started_on, null: false
       t.date :finished_on
+
       t.index "ect_at_school_period_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+      t.index "ect_at_school_period_id, started_on", unique: true
 
       t.timestamps
     end

--- a/db/migrate/20240830140640_import_tables.rb
+++ b/db/migrate/20240830140640_import_tables.rb
@@ -1,0 +1,136 @@
+class ImportTables < ActiveRecord::Migration[7.2]
+  def change
+    create_table :academic_years do |t|
+      t.integer :year, null: false
+
+      t.timestamps
+    end
+
+    create_table :lead_providers do |t|
+      t.string :name
+
+      t.timestamps
+    end
+
+    create_table :delivery_partners do |t|
+      t.string :name
+
+      t.timestamps
+    end
+
+    create_table :teachers do |t|
+      t.string :name
+
+      t.timestamps
+    end
+
+    create_table :appropriate_bodies do |t|
+      t.string :name
+
+      t.timestamps
+    end
+
+    create_enum :gias_school_statuses, %w[open closed proposed_to_close proposed_to_open]
+
+    create_table :gias_schools, primary_key: :urn do |t|
+      t.string :name, null: false
+      t.integer :local_authority
+      t.string :school_phase
+      t.string :school_type
+
+      t.enum :school_status, default: "open", null: false, enum_type: :gias_school_statuses
+
+      t.string :administrative_district
+
+      t.string :address_line1
+      t.string :address_line2
+      t.string :address_line3
+      t.string :postcode
+
+      t.string :primary_contact_email
+      t.string :secondary_contact_email
+      t.boolean :section_41_approved
+      t.date :opened_on
+      t.date :closed_on
+
+      t.timestamps
+    end
+
+    create_enum :induction_eligibility_status, %w[eligible ineligible]
+    create_enum :funding_eligibility_status, %w[eligible_for_fip eligible_for_cip ineligible]
+
+    create_table :schools do |t|
+      t.integer :urn, null: false, index: { unique: true, name: "schools_unique_urn" }
+      t.enum :induction_eligibility, null: false, enum_type: :induction_eligibility_status
+      t.enum :funding_eligibility, null: false, enum_type: :funding_eligibility_status
+
+      t.timestamps
+    end
+
+    create_table :ect_at_school_periods do |t|
+      t.references :school
+      t.references :teacher
+      t.date :started_on, null: false
+      t.date :finished_on
+      t.index "school_id, teacher_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+
+      t.timestamps
+    end
+
+    create_table :mentor_at_school_periods do |t|
+      t.references :school
+      t.references :teacher
+      t.date :started_on, null: false
+      t.date :finished_on
+      t.index "school_id, teacher_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+
+      t.timestamps
+    end
+
+    create_table :mentorship_periods do |t|
+      t.references :ect_at_school_period
+      t.references :mentor_at_school_period
+      t.date :started_on, null: false
+      t.date :finished_on
+      t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+
+      t.timestamps
+    end
+
+    create_table :provider_partnerships do |t|
+      t.references :academic_year
+      t.references :lead_provider
+      t.references :delivery_partner
+
+      t.timestamps
+    end
+
+    create_table :training_periods do |t|
+      t.references :provider_partnership
+      t.references :ect_at_school_period
+      t.references :mentor_at_school_period
+      t.date :started_on, null: false
+      t.date :finished_on
+      t.index "ect_at_school_period_id, mentor_at_school_period_id, provider_partnership_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+
+      t.timestamps
+    end
+
+    create_table :declarations do |t|
+      t.references :training_period
+      t.string :declaration_type
+
+      t.timestamps
+    end
+
+    create_table :induction_periods do |t|
+      t.references :ect_at_school_period
+      t.references :appropriate_body
+      t.date :started_on, null: false
+      t.date :finished_on
+      t.index "ect_at_school_period_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240905183321_replace_polymorphism_in_training_periods.rb
+++ b/db/migrate/20240905183321_replace_polymorphism_in_training_periods.rb
@@ -1,0 +1,14 @@
+class ReplacePolymorphismInTrainingPeriods < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :training_periods, "trainee_id, trainee_type, ((finished_on IS NULL))", if_exists: true
+    remove_index :training_periods, "trainee_id, trainee_type, started_on", if_exists: true
+    remove_index :training_periods, name: "provider_partnership_trainings", column: "provider_partnership_id, trainee_id, trainee_type, started_on", if_exists: true
+    remove_reference :training_periods, :trainee, null: false, polymorphic: true
+
+    add_reference :training_periods, :ect_at_school_period, foreign_key: true
+    add_reference :training_periods, :mentor_at_school_period, foreign_key: true
+    add_index :training_periods, "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", unique: true, where: "(finished_on IS NULL)"
+    add_index :training_periods, %i[ect_at_school_period_id mentor_at_school_period_id started_on], unique: true
+    add_index :training_periods, %i[provider_partnership_id ect_at_school_period_id mentor_at_school_period_id started_on], unique: true, name: "provider_partnership_trainings"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,8 +61,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
   create_table "gias_schools", primary_key: "urn", force: :cascade do |t|
     t.string "name", null: false
     t.integer "local_authority"
-    t.string "school_phase"
-    t.string "school_type"
+    t.string "phase"
+    t.string "establishment_type"
     t.enum "school_status", default: "open", null: false, enum_type: "gias_school_statuses"
     t.string "administrative_district"
     t.string "address_line1"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_05_183321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -283,17 +283,18 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
 
   create_table "training_periods", force: :cascade do |t|
     t.bigint "provider_partnership_id", null: false
-    t.string "trainee_type", null: false
-    t.bigint "trainee_id", null: false
     t.date "started_on", null: false
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "trainee_id, trainee_type, ((finished_on IS NULL))", name: "idx_on_trainee_id_trainee_type_finished_on_IS_NULL_37242fff94", unique: true, where: "(finished_on IS NULL)"
-    t.index ["provider_partnership_id", "trainee_id", "trainee_type", "started_on"], name: "provider_partnership_trainings", unique: true
+    t.bigint "ect_at_school_period_id"
+    t.bigint "mentor_at_school_period_id"
+    t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_42bce3bf48", unique: true, where: "(finished_on IS NULL)"
+    t.index ["ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "idx_on_ect_at_school_period_id_mentor_at_school_per_70f2bb1a45", unique: true
+    t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"
+    t.index ["mentor_at_school_period_id"], name: "index_training_periods_on_mentor_at_school_period_id"
+    t.index ["provider_partnership_id", "ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "provider_partnership_trainings", unique: true
     t.index ["provider_partnership_id"], name: "index_training_periods_on_provider_partnership_id"
-    t.index ["trainee_id", "trainee_type", "started_on"], name: "index_training_periods_on_trainee_id_trainee_type_started_on", unique: true
-    t.index ["trainee_type", "trainee_id"], name: "index_training_periods_on_trainee"
   end
 
   add_foreign_key "ect_at_school_periods", "schools"
@@ -313,5 +314,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "training_periods", "ect_at_school_periods"
+  add_foreign_key "training_periods", "mentor_at_school_periods"
   add_foreign_key "training_periods", "provider_partnerships"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,16 +20,17 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
   create_enum "gias_school_statuses", ["open", "closed", "proposed_to_close", "proposed_to_open"]
   create_enum "induction_eligibility_status", ["eligible", "ineligible"]
 
-  create_table "academic_years", force: :cascade do |t|
-    t.integer "year", null: false
+  create_table "academic_years", primary_key: "year", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["year"], name: "index_academic_years_on_year", unique: true
   end
 
   create_table "appropriate_bodies", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_appropriate_bodies_on_name", unique: true
   end
 
   create_table "declarations", force: :cascade do |t|
@@ -41,20 +42,23 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
   end
 
   create_table "delivery_partners", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_delivery_partners_on_name", unique: true
   end
 
   create_table "ect_at_school_periods", force: :cascade do |t|
-    t.bigint "school_id"
-    t.bigint "teacher_id"
+    t.bigint "school_id", null: false
+    t.bigint "teacher_id", null: false
     t.date "started_on", null: false
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_abe4626dca", unique: true, where: "(finished_on IS NULL)"
+    t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
+    t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
     t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
+    t.index ["teacher_id", "started_on"], name: "index_ect_at_school_periods_on_teacher_id_started_on", unique: true
     t.index ["teacher_id"], name: "index_ect_at_school_periods_on_teacher_id"
   end
 
@@ -64,6 +68,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
     t.string "phase"
     t.string "establishment_type"
     t.enum "school_status", default: "open", null: false, enum_type: "gias_school_statuses"
+    t.enum "induction_eligibility", null: false, enum_type: "induction_eligibility_status"
+    t.enum "funding_eligibility", null: false, enum_type: "funding_eligibility_status"
     t.string "administrative_district"
     t.string "address_line1"
     t.string "address_line2"
@@ -79,53 +85,60 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
   end
 
   create_table "induction_periods", force: :cascade do |t|
-    t.bigint "ect_at_school_period_id"
-    t.bigint "appropriate_body_id"
+    t.bigint "appropriate_body_id", null: false
+    t.bigint "ect_at_school_period_id", null: false
     t.date "started_on", null: false
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_be6c214e9d", unique: true, where: "(finished_on IS NULL)"
     t.index ["appropriate_body_id"], name: "index_induction_periods_on_appropriate_body_id"
+    t.index ["ect_at_school_period_id", "started_on"], name: "index_induction_periods_on_ect_at_school_period_id_started_on", unique: true
     t.index ["ect_at_school_period_id"], name: "index_induction_periods_on_ect_at_school_period_id"
   end
 
   create_table "lead_providers", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_lead_providers_on_name", unique: true
   end
 
   create_table "mentor_at_school_periods", force: :cascade do |t|
-    t.bigint "school_id"
-    t.bigint "teacher_id"
+    t.bigint "school_id", null: false
+    t.bigint "teacher_id", null: false
     t.date "started_on", null: false
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_dd7ee16a28", unique: true, where: "(finished_on IS NULL)"
+    t.index ["school_id", "teacher_id", "started_on"], name: "idx_on_school_id_teacher_id_started_on_17d46e7783", unique: true
     t.index ["school_id"], name: "index_mentor_at_school_periods_on_school_id"
+    t.index ["teacher_id", "started_on"], name: "index_mentor_at_school_periods_on_teacher_id_started_on", unique: true
     t.index ["teacher_id"], name: "index_mentor_at_school_periods_on_teacher_id"
   end
 
   create_table "mentorship_periods", force: :cascade do |t|
-    t.bigint "ect_at_school_period_id"
-    t.bigint "mentor_at_school_period_id"
+    t.bigint "ect_at_school_period_id", null: false
+    t.bigint "mentor_at_school_period_id", null: false
     t.date "started_on", null: false
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_482f52b217", unique: true, where: "(finished_on IS NULL)"
+    t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_afd5cf131d", unique: true, where: "(finished_on IS NULL)"
+    t.index ["ect_at_school_period_id", "started_on"], name: "index_mentorship_periods_on_ect_at_school_period_id_started_on", unique: true
     t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
+    t.index ["mentor_at_school_period_id", "ect_at_school_period_id", "started_on"], name: "idx_on_mentor_at_school_period_id_ect_at_school_per_d69dffeecc", unique: true
     t.index ["mentor_at_school_period_id"], name: "index_mentorship_periods_on_mentor_at_school_period_id"
   end
 
   create_table "provider_partnerships", force: :cascade do |t|
-    t.bigint "academic_year_id"
-    t.bigint "lead_provider_id"
-    t.bigint "delivery_partner_id"
+    t.bigint "academic_year_id", null: false
+    t.bigint "lead_provider_id", null: false
+    t.bigint "delivery_partner_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["academic_year_id", "lead_provider_id", "delivery_partner_id"], name: "yearly_unique_provider_partnerships", unique: true
     t.index ["academic_year_id"], name: "index_provider_partnerships_on_academic_year_id"
     t.index ["delivery_partner_id"], name: "index_provider_partnerships_on_delivery_partner_id"
     t.index ["lead_provider_id"], name: "index_provider_partnerships_on_lead_provider_id"
@@ -133,10 +146,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
 
   create_table "schools", force: :cascade do |t|
     t.integer "urn", null: false
-    t.enum "induction_eligibility", null: false, enum_type: "induction_eligibility_status"
-    t.enum "funding_eligibility", null: false, enum_type: "funding_eligibility_status"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_schools_on_name", unique: true
     t.index ["urn"], name: "schools_unique_urn", unique: true
   end
 
@@ -262,29 +275,43 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
   end
 
   create_table "teachers", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_teachers_on_name"
   end
 
   create_table "training_periods", force: :cascade do |t|
-    t.bigint "provider_partnership_id"
-    t.bigint "ect_at_school_period_id"
-    t.bigint "mentor_at_school_period_id"
+    t.bigint "provider_partnership_id", null: false
+    t.string "trainee_type", null: false
+    t.bigint "trainee_id", null: false
     t.date "started_on", null: false
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "ect_at_school_period_id, mentor_at_school_period_id, provider_partnership_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_442268543c", unique: true, where: "(finished_on IS NULL)"
-    t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"
-    t.index ["mentor_at_school_period_id"], name: "index_training_periods_on_mentor_at_school_period_id"
+    t.index "trainee_id, trainee_type, ((finished_on IS NULL))", name: "idx_on_trainee_id_trainee_type_finished_on_IS_NULL_37242fff94", unique: true, where: "(finished_on IS NULL)"
+    t.index ["provider_partnership_id", "trainee_id", "trainee_type", "started_on"], name: "provider_partnership_trainings", unique: true
     t.index ["provider_partnership_id"], name: "index_training_periods_on_provider_partnership_id"
+    t.index ["trainee_id", "trainee_type", "started_on"], name: "index_training_periods_on_trainee_id_trainee_type_started_on", unique: true
+    t.index ["trainee_type", "trainee_id"], name: "index_training_periods_on_trainee"
   end
 
+  add_foreign_key "ect_at_school_periods", "schools"
+  add_foreign_key "ect_at_school_periods", "teachers"
+  add_foreign_key "induction_periods", "appropriate_bodies"
+  add_foreign_key "induction_periods", "ect_at_school_periods"
+  add_foreign_key "mentor_at_school_periods", "schools"
+  add_foreign_key "mentor_at_school_periods", "teachers"
+  add_foreign_key "mentorship_periods", "ect_at_school_periods"
+  add_foreign_key "mentorship_periods", "mentor_at_school_periods"
+  add_foreign_key "provider_partnerships", "academic_years", primary_key: "year"
+  add_foreign_key "provider_partnerships", "delivery_partners"
+  add_foreign_key "provider_partnerships", "lead_providers"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "training_periods", "provider_partnerships"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,132 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  # Custom types defined in this database.
+  # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "funding_eligibility_status", ["eligible_for_fip", "eligible_for_cip", "ineligible"]
+  create_enum "gias_school_statuses", ["open", "closed", "proposed_to_close", "proposed_to_open"]
+  create_enum "induction_eligibility_status", ["eligible", "ineligible"]
+
+  create_table "academic_years", force: :cascade do |t|
+    t.integer "year", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "appropriate_bodies", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "declarations", force: :cascade do |t|
+    t.bigint "training_period_id"
+    t.string "declaration_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["training_period_id"], name: "index_declarations_on_training_period_id"
+  end
+
+  create_table "delivery_partners", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "ect_at_school_periods", force: :cascade do |t|
+    t.bigint "school_id"
+    t.bigint "teacher_id"
+    t.date "started_on", null: false
+    t.date "finished_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_abe4626dca", unique: true, where: "(finished_on IS NULL)"
+    t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
+    t.index ["teacher_id"], name: "index_ect_at_school_periods_on_teacher_id"
+  end
+
+  create_table "gias_schools", primary_key: "urn", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "local_authority"
+    t.string "school_phase"
+    t.string "school_type"
+    t.enum "school_status", default: "open", null: false, enum_type: "gias_school_statuses"
+    t.string "administrative_district"
+    t.string "address_line1"
+    t.string "address_line2"
+    t.string "address_line3"
+    t.string "postcode"
+    t.string "primary_contact_email"
+    t.string "secondary_contact_email"
+    t.boolean "section_41_approved"
+    t.date "opened_on"
+    t.date "closed_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "induction_periods", force: :cascade do |t|
+    t.bigint "ect_at_school_period_id"
+    t.bigint "appropriate_body_id"
+    t.date "started_on", null: false
+    t.date "finished_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_be6c214e9d", unique: true, where: "(finished_on IS NULL)"
+    t.index ["appropriate_body_id"], name: "index_induction_periods_on_appropriate_body_id"
+    t.index ["ect_at_school_period_id"], name: "index_induction_periods_on_ect_at_school_period_id"
+  end
+
+  create_table "lead_providers", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "mentor_at_school_periods", force: :cascade do |t|
+    t.bigint "school_id"
+    t.bigint "teacher_id"
+    t.date "started_on", null: false
+    t.date "finished_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_dd7ee16a28", unique: true, where: "(finished_on IS NULL)"
+    t.index ["school_id"], name: "index_mentor_at_school_periods_on_school_id"
+    t.index ["teacher_id"], name: "index_mentor_at_school_periods_on_teacher_id"
+  end
+
+  create_table "mentorship_periods", force: :cascade do |t|
+    t.bigint "ect_at_school_period_id"
+    t.bigint "mentor_at_school_period_id"
+    t.date "started_on", null: false
+    t.date "finished_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_482f52b217", unique: true, where: "(finished_on IS NULL)"
+    t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
+    t.index ["mentor_at_school_period_id"], name: "index_mentorship_periods_on_mentor_at_school_period_id"
+  end
+
+  create_table "provider_partnerships", force: :cascade do |t|
+    t.bigint "academic_year_id"
+    t.bigint "lead_provider_id"
+    t.bigint "delivery_partner_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["academic_year_id"], name: "index_provider_partnerships_on_academic_year_id"
+    t.index ["delivery_partner_id"], name: "index_provider_partnerships_on_delivery_partner_id"
+    t.index ["lead_provider_id"], name: "index_provider_partnerships_on_lead_provider_id"
+  end
+
+  create_table "schools", force: :cascade do |t|
+    t.integer "urn", null: false
+    t.enum "induction_eligibility", null: false, enum_type: "induction_eligibility_status"
+    t.enum "funding_eligibility", null: false, enum_type: "funding_eligibility_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["urn"], name: "schools_unique_urn", unique: true
+  end
+
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
     t.bigint "job_id", null: false
     t.string "queue_name", null: false
@@ -133,6 +259,26 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_163610) do
     t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
     t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  create_table "teachers", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "training_periods", force: :cascade do |t|
+    t.bigint "provider_partnership_id"
+    t.bigint "ect_at_school_period_id"
+    t.bigint "mentor_at_school_period_id"
+    t.date "started_on", null: false
+    t.date "finished_on"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index "ect_at_school_period_id, mentor_at_school_period_id, provider_partnership_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_442268543c", unique: true, where: "(finished_on IS NULL)"
+    t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"
+    t.index ["mentor_at_school_period_id"], name: "index_training_periods_on_mentor_at_school_period_id"
+    t.index ["provider_partnership_id"], name: "index_training_periods_on_provider_partnership_id"
   end
 
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/spec/factories/academic_year_factory.rb
+++ b/spec/factories/academic_year_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  sequence(:base_academic_year, 2021)
+
+  factory(:academic_year) do
+    year { generate(:base_academic_year) }
+  end
+end

--- a/spec/factories/appropriate_body_factory.rb
+++ b/spec/factories/appropriate_body_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory(:appropriate_body) do
+    name { "#{Faker::Lorem.word.capitalize} AB" }
+  end
+end

--- a/spec/factories/delivery_partner_factory.rb
+++ b/spec/factories/delivery_partner_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory(:delivery_partner) do
-    name { "#{Faker::Lorem.word.capitalize} DP" }
+    name { "#{Faker::Lorem.word.capitalize} DP (#{rand(100..999)})" }
   end
 end

--- a/spec/factories/delivery_partner_factory.rb
+++ b/spec/factories/delivery_partner_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory(:delivery_partner) do
+    name { "#{Faker::Lorem.word.capitalize} DP" }
+  end
+end

--- a/spec/factories/ect_at_school_period_factory.rb
+++ b/spec/factories/ect_at_school_period_factory.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  sequence(:base_ect_date) { |n| 2.years.ago.to_date + (3 * n).months }
+
+  factory(:ect_at_school_period) do
+    association :school
+    association :teacher
+
+    started_on { generate(:base_ect_date) }
+    finished_on { started_on + 3.months }
+
+    trait :active do
+      finished_on { nil }
+    end
+  end
+end

--- a/spec/factories/induction_period_factory.rb
+++ b/spec/factories/induction_period_factory.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  sequence(:base_induction_date) { |n| 2.years.ago.to_date + (3 * n).months }
+
+  factory(:induction_period) do
+    association :appropriate_body
+    association :ect_at_school_period
+
+    started_on { generate(:base_induction_date) }
+    finished_on { started_on + 3.months }
+
+    trait :active do
+      finished_on { nil }
+    end
+  end
+end

--- a/spec/factories/lead_provider_factory.rb
+++ b/spec/factories/lead_provider_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory(:lead_provider) do
+    name { "#{Faker::Lorem.word.capitalize} LP" }
+  end
+end

--- a/spec/factories/lead_provider_factory.rb
+++ b/spec/factories/lead_provider_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory(:lead_provider) do
-    name { "#{Faker::Lorem.word.capitalize} LP" }
+    name { "#{Faker::Lorem.word.capitalize} LP (#{rand(100..999)})" }
   end
 end

--- a/spec/factories/mentor_at_school_period_factory.rb
+++ b/spec/factories/mentor_at_school_period_factory.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  sequence(:base_mentor_date) { |n| 2.years.ago.to_date + (3 * n).months }
+
+  factory(:mentor_at_school_period) do
+    association :school
+    association :teacher
+
+    started_on { generate(:base_mentor_date) }
+    finished_on { started_on + 3.months }
+
+    trait :active do
+      finished_on { nil }
+    end
+  end
+end

--- a/spec/factories/mentorship_period_factory.rb
+++ b/spec/factories/mentorship_period_factory.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  sequence(:base_mentorship_date) { |n| 2.years.ago.to_date + (3 * n).months }
+
+  factory(:mentorship_period) do
+    association :mentee, factory: :ect_at_school_period
+    association :mentor, factory: :mentor_at_school_period
+
+    started_on { generate(:base_mentorship_date) }
+    finished_on { started_on + 3.months }
+
+    trait :active do
+      finished_on { nil }
+    end
+  end
+end

--- a/spec/factories/provider_partnership_factory.rb
+++ b/spec/factories/provider_partnership_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory(:provider_partnership) do
+    association :academic_year
+    association :lead_provider
+    association :delivery_partner
+  end
+end

--- a/spec/factories/school_factory.rb
+++ b/spec/factories/school_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory(:school) do
+    urn { Faker::Number.unique.decimal_part(digits: 7).to_s }
+    name { Faker::Educator.primary_school + " (#{rand(100..999)})" }
+  end
+end

--- a/spec/factories/teacher_factory.rb
+++ b/spec/factories/teacher_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory(:teacher) do
+    name { [Faker::Name.name, Faker::Name.last_name].join(" ") }
+  end
+end

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  sequence(:base_training_date) { |n| 2.years.ago.to_date + (3 * n).months }
+
+  factory(:training_period) do
+    for_ect
+    association :provider_partnership
+
+    started_on { generate(:base_training_date) }
+    finished_on { started_on + 3.months }
+
+    trait :active do
+      finished_on { nil }
+    end
+
+    trait(:for_ect) do
+      association :trainee, factory: :ect_at_school_period
+    end
+
+    trait(:for_mentor) do
+      association :trainee, factory: :mentor_at_school_period
+    end
+  end
+end

--- a/spec/factories/training_period_factory.rb
+++ b/spec/factories/training_period_factory.rb
@@ -13,11 +13,13 @@ FactoryBot.define do
     end
 
     trait(:for_ect) do
-      association :trainee, factory: :ect_at_school_period
+      association :ect_at_school_period
+      mentor_at_school_period { nil }
     end
 
     trait(:for_mentor) do
-      association :trainee, factory: :mentor_at_school_period
+      association :mentor_at_school_period
+      ect_at_school_period { nil }
     end
   end
 end

--- a/spec/models/academic_year_spec.rb
+++ b/spec/models/academic_year_spec.rb
@@ -1,0 +1,13 @@
+describe AcademicYear do
+  describe "associations" do
+    it { is_expected.to have_many(:provider_partnerships) }
+  end
+
+  describe "validations" do
+    subject { build(:academic_year) }
+
+    it { is_expected.to validate_presence_of(:year) }
+    it { is_expected.to validate_uniqueness_of(:year) }
+    it { is_expected.to validate_numericality_of(:year).only_integer.is_greater_than_or_equal_to(2020) }
+  end
+end

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -1,0 +1,12 @@
+describe AppropriateBody do
+  describe "associations" do
+    it { is_expected.to have_many(:induction_periods) }
+  end
+
+  describe "validations" do
+    subject { build(:appropriate_body) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name) }
+  end
+end

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -1,0 +1,81 @@
+describe Interval do
+  describe "validations" do
+    context "period dates" do
+      context "when finished_on is earlier than started_on" do
+        subject { DummyMentor.new(started_on: Date.yesterday, finished_on: 2.days.ago) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(finished_on: ["Must be later than :started_on"])
+        end
+      end
+
+      context "when finished_on matches started_on" do
+        subject { DummyMentor.new(started_on: Date.yesterday, finished_on: Date.yesterday) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(finished_on: ["Must be later than :started_on"])
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    let!(:teacher_id) { create(:teacher, name: "Teacher One").id }
+    let!(:teacher_2_id) { create(:teacher, name: "Teacher Two").id }
+    let!(:school_id) { create(:school, urn: "1234567").id }
+    let!(:period_1) { DummyMentor.create(teacher_id:, school_id:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { DummyMentor.create(teacher_id:, school_id:, started_on: '2023-07-01', finished_on: '2023-12-01') }
+    let!(:period_3) { DummyMentor.create(teacher_id:, school_id:, started_on: '2024-01-01', finished_on: nil) }
+    let!(:teacher_2_period) do
+      DummyMentor.create(teacher_id: teacher_2_id, school_id:, started_on: '2023-02-01', finished_on: '2023-07-01')
+    end
+
+    describe ".extending_later_than" do
+      it "returns periods with finished_on later than the specified date or not finished" do
+        expect(DummyMentor.extending_later_than('2023-05-01')).to match_array([period_1, period_2, period_3, teacher_2_period])
+      end
+
+      it "does not return periods finished before the specified date" do
+        expect(DummyMentor.extending_later_than('2023-07-02')).to match_array([period_2, period_3])
+      end
+    end
+
+    describe ".starting_earlier_than" do
+      it "returns periods with started_on earlier than the specified date" do
+        expect(DummyMentor.starting_earlier_than('2023-08-01')).to match_array([period_1, period_2, teacher_2_period])
+      end
+
+      it "does not return periods with started_on on or after the specified date" do
+        expect(DummyMentor.starting_earlier_than('2023-01-01')).to be_empty
+      end
+    end
+
+    describe ".overlapping" do
+      it "returns periods overlapping with the specified date range" do
+        expect(DummyMentor.overlapping('2023-02-01', '2023-10-01')).to match_array([period_1, period_2, teacher_2_period])
+      end
+
+      it "returns periods starting after the specified start date if end date is nil" do
+        expect(DummyMentor.overlapping('2024-01-01', nil)).to match_array([period_3])
+      end
+
+      it "does not return periods outside the specified date range" do
+        expect(DummyMentor.overlapping('2022-01-01', '2022-12-31')).to be_empty
+      end
+    end
+  end
+end
+
+class DummyMentor < ApplicationRecord
+  include Interval
+
+  self.table_name = "mentor_at_school_periods"
+end

--- a/spec/models/delivery_partner_spec.rb
+++ b/spec/models/delivery_partner_spec.rb
@@ -1,0 +1,12 @@
+describe DeliveryPartner do
+  describe "associations" do
+    it { is_expected.to have_many(:provider_partnerships) }
+  end
+
+  describe "validations" do
+    subject { build(:delivery_partner) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name) }
+  end
+end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -1,0 +1,109 @@
+describe ECTAtSchoolPeriod do
+  describe "associations" do
+    it { is_expected.to belong_to(:school).inverse_of(:ect_at_school_periods) }
+    it { is_expected.to belong_to(:teacher).inverse_of(:ect_at_school_periods) }
+    it { is_expected.to have_many(:induction_periods).inverse_of(:ect_at_school_period) }
+    it { is_expected.to have_many(:mentorship_periods).inverse_of(:mentee) }
+    it { is_expected.to have_many(:training_periods) }
+  end
+
+  describe "validations" do
+    subject { create(:ect_at_school_period) }
+
+    it { is_expected.to validate_uniqueness_of(:finished_on).scoped_to(:teacher_id).allow_nil }
+    it { is_expected.to validate_presence_of(:started_on) }
+    it { is_expected.to validate_uniqueness_of(:started_on).scoped_to(:teacher_id) }
+    it { is_expected.to validate_presence_of(:school_id) }
+    it { is_expected.to validate_presence_of(:teacher_id) }
+
+    context "school presence" do
+      context "when the school does not exist" do
+        subject { build(:ect_at_school_period, school_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(school_id: ["School does not exist"])
+        end
+      end
+    end
+
+    context "teacher distinct period" do
+      context "when the period has not finished yet" do
+        context "when the teacher has a sibling ect_at_school_period starting later" do
+          let!(:existing_period) { create(:ect_at_school_period) }
+          let(:teacher_id) { existing_period.teacher_id }
+          let(:started_on) { existing_period.started_on - 1.year }
+
+          subject { build(:ect_at_school_period, teacher_id:, started_on:, finished_on: nil) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Teacher ECT periods cannot overlap"])
+          end
+        end
+      end
+
+      context "when the period has end date" do
+        context "when the teacher has a sibling ect_at_school_period overlapping" do
+          let!(:existing_period) { create(:ect_at_school_period) }
+          let(:teacher_id) { existing_period.teacher_id }
+          let(:started_on) { existing_period.finished_on - 1.day }
+          let(:finished_on) { started_on + 1.day }
+
+          subject { build(:ect_at_school_period, teacher_id:, started_on:, finished_on:) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Teacher ECT periods cannot overlap"])
+          end
+        end
+      end
+    end
+
+    context "teacher presence" do
+      context "when the teacher does not exist" do
+        subject { build(:ect_at_school_period, teacher_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(teacher_id: ["Teacher does not exist"])
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    let!(:teacher) { create(:teacher) }
+    let!(:school) { create(:school) }
+    let!(:period_1) { create(:ect_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:ect_at_school_period, teacher:, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:period_3) { create(:ect_at_school_period, teacher:, school:, started_on: '2024-01-01', finished_on: nil) }
+    let!(:teacher_2_period) { create(:ect_at_school_period, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+
+    describe ".for_teacher" do
+      it "returns ect periods only for the specified teacher" do
+        expect(described_class.for_teacher(teacher.id)).to match_array([period_1, period_2, period_3])
+      end
+    end
+
+    describe ".siblings_of" do
+      let(:ect_at_school_period) { build(:ect_at_school_period, teacher:, school:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+
+      it "returns ect periods only for the specified instance's teacher excluding the instance" do
+        expect(described_class.siblings_of(ect_at_school_period)).to match_array([period_1, period_2, period_3])
+      end
+    end
+  end
+end

--- a/spec/models/ect_at_school_period_spec.rb
+++ b/spec/models/ect_at_school_period_spec.rb
@@ -16,20 +16,6 @@ describe ECTAtSchoolPeriod do
     it { is_expected.to validate_presence_of(:school_id) }
     it { is_expected.to validate_presence_of(:teacher_id) }
 
-    context "school presence" do
-      context "when the school does not exist" do
-        subject { build(:ect_at_school_period, school_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(school_id: ["School does not exist"])
-        end
-      end
-    end
-
     context "teacher distinct period" do
       context "when the period has not finished yet" do
         context "when the teacher has a sibling ect_at_school_period starting later" do
@@ -65,20 +51,6 @@ describe ECTAtSchoolPeriod do
           it "add an error" do
             expect(subject.errors.messages).to include(base: ["Teacher ECT periods cannot overlap"])
           end
-        end
-      end
-    end
-
-    context "teacher presence" do
-      context "when the teacher does not exist" do
-        subject { build(:ect_at_school_period, teacher_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(teacher_id: ["Teacher does not exist"])
         end
       end
     end

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -22,34 +22,6 @@ describe InductionPeriod do
     it { is_expected.to validate_presence_of(:appropriate_body_id) }
     it { is_expected.to validate_presence_of(:ect_at_school_period_id) }
 
-    context "appropriate body presence" do
-      context "when the appropriate body does not exist" do
-        subject { build(:induction_period, appropriate_body_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(appropriate_body_id: ["Appropriate body not registered"])
-        end
-      end
-    end
-
-    context "ect_at_school_period presence" do
-      context "when the ect_at_school_period does not exist" do
-        subject { build(:induction_period, ect_at_school_period_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(ect_at_school_period_id: ["ECT period not registered"])
-        end
-      end
-    end
-
     context "teacher distinct period" do
       context "when the period has not finished yet" do
         context "when the ect has a sibling induction period starting later" do

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -1,0 +1,121 @@
+describe InductionPeriod do
+  describe "associations" do
+    it { is_expected.to belong_to(:appropriate_body) }
+    it { is_expected.to belong_to(:ect_at_school_period).inverse_of(:induction_periods) }
+  end
+
+  describe "validations" do
+    subject { create(:induction_period) }
+
+    it {
+      is_expected.to validate_uniqueness_of(:finished_on)
+                          .scoped_to(:ect_at_school_period_id)
+                          .allow_nil
+                          .with_message("matches the end date of an existing period for ECT")
+    }
+
+    it {
+      is_expected.to validate_uniqueness_of(:started_on)
+                          .scoped_to(:ect_at_school_period_id)
+                          .with_message("matches the start date of an existing period for ECT")
+    }
+    it { is_expected.to validate_presence_of(:appropriate_body_id) }
+    it { is_expected.to validate_presence_of(:ect_at_school_period_id) }
+
+    context "appropriate body presence" do
+      context "when the appropriate body does not exist" do
+        subject { build(:induction_period, appropriate_body_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(appropriate_body_id: ["Appropriate body not registered"])
+        end
+      end
+    end
+
+    context "ect_at_school_period presence" do
+      context "when the ect_at_school_period does not exist" do
+        subject { build(:induction_period, ect_at_school_period_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(ect_at_school_period_id: ["ECT period not registered"])
+        end
+      end
+    end
+
+    context "teacher distinct period" do
+      context "when the period has not finished yet" do
+        context "when the ect has a sibling induction period starting later" do
+          let!(:existing_period) { create(:induction_period) }
+          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
+          let(:started_on) { existing_period.started_on - 1.year }
+
+          subject { build(:induction_period, ect_at_school_period_id:, started_on:, finished_on: nil) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Teacher induction periods cannot overlap"])
+          end
+        end
+      end
+
+      context "when the period has end date" do
+        context "when the ECT has a sibling induction period overlapping" do
+          let!(:existing_period) { create(:induction_period) }
+          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
+          let(:started_on) { existing_period.finished_on - 1.day }
+          let(:finished_on) { started_on + 1.day }
+
+          subject { build(:induction_period, ect_at_school_period_id:, started_on:, finished_on:) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Teacher induction periods cannot overlap"])
+          end
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    let!(:ect_at_school_period) { create(:ect_at_school_period) }
+    let!(:appropriate_body) { create(:appropriate_body) }
+    let!(:period_1) { create(:induction_period, ect_at_school_period:, appropriate_body:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:induction_period, ect_at_school_period:, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:period_3) { create(:induction_period, ect_at_school_period:, appropriate_body:, started_on: '2024-01-01', finished_on: nil) }
+    let!(:ect_2_period) { create(:induction_period, appropriate_body:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+
+    describe ".for_ect" do
+      it "returns induction periods only for the specified ect at school period" do
+        expect(described_class.for_ect(ect_at_school_period.id)).to match_array([period_1, period_2, period_3])
+      end
+    end
+
+    describe ".for_appropriate_body" do
+      it "returns induction periods only for the specified appropriate_body" do
+        expect(described_class.for_appropriate_body(appropriate_body.id)).to match_array([period_1, period_3, ect_2_period])
+      end
+    end
+
+    describe ".siblings_of" do
+      let(:induction_period) { build(:induction_period, ect_at_school_period:, appropriate_body:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+
+      it "returns induction periods only for the specified instance's ect excluding the instance" do
+        expect(described_class.siblings_of(induction_period)).to match_array([period_1, period_2, period_3])
+      end
+    end
+  end
+end

--- a/spec/models/lead_provider_spec.rb
+++ b/spec/models/lead_provider_spec.rb
@@ -1,0 +1,12 @@
+describe LeadProvider do
+  describe "associations" do
+    it { is_expected.to have_many(:provider_partnerships) }
+  end
+
+  describe "validations" do
+    subject { build(:lead_provider) }
+
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name) }
+  end
+end

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -1,0 +1,162 @@
+describe MentorAtSchoolPeriod do
+  describe "associations" do
+    it { is_expected.to belong_to(:school).inverse_of(:mentor_at_school_periods) }
+    it { is_expected.to belong_to(:teacher).inverse_of(:mentor_at_school_periods) }
+    it { is_expected.to have_many(:mentorship_periods).inverse_of(:mentor) }
+    it { is_expected.to have_many(:training_periods) }
+  end
+
+  describe "validations" do
+    subject { build(:mentor_at_school_period) }
+
+    it { is_expected.to validate_presence_of(:started_on) }
+    it { is_expected.to validate_presence_of(:school_id) }
+    it { is_expected.to validate_presence_of(:teacher_id) }
+
+    context "uniqueness of finished_on scoped to teacher_id and school_id" do
+      context "when the period matches the teacher_id, school_id and finished_on values of an existing mentor period" do
+        let!(:existing_period) { create(:mentor_at_school_period) }
+        let(:finished_on) { existing_period.finished_on }
+        let(:started_on) { existing_period.finished_on - 1.day }
+        let(:school_id) { existing_period.school_id }
+        let(:teacher_id) { existing_period.teacher_id }
+
+        subject { build(:mentor_at_school_period, teacher_id:, school_id:, started_on:, finished_on:) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(finished_on: ["matches the end date of an existing period"])
+        end
+      end
+    end
+
+    context "uniqueness of started_on scoped to teacher_id and school_id" do
+      context "when the period matches the teacher_id, school_id and started_on values of an existing mentor period" do
+        let!(:existing_period) { create(:mentor_at_school_period) }
+        let(:started_on) { existing_period.started_on }
+        let(:school_id) { existing_period.school_id }
+        let(:teacher_id) { existing_period.teacher_id }
+
+        subject { build(:mentor_at_school_period, teacher_id:, school_id:, started_on:) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(started_on: ["matches the start date of an existing period"])
+        end
+      end
+    end
+
+    context "school presence" do
+      context "when the school does not exist" do
+        subject { build(:mentor_at_school_period, school_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(school_id: ["School does not exist"])
+        end
+      end
+    end
+
+    context "teacher school distinct period" do
+      context "when the period has not finished yet" do
+        context "when the teacher has a school sibling mentor_at_school_period starting later" do
+          let!(:existing_period) { create(:mentor_at_school_period) }
+          let(:teacher_id) { existing_period.teacher_id }
+          let(:school_id) { existing_period.school_id }
+          let(:started_on) { existing_period.started_on - 1.year }
+
+          subject { build(:mentor_at_school_period, teacher_id:, school_id:, started_on:, finished_on: nil) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Teacher School ECT periods cannot overlap"])
+          end
+        end
+      end
+
+      context "when the period has end date" do
+        context "when the teacher has a sibling ect_at_school_period overlapping" do
+          let!(:existing_period) { create(:mentor_at_school_period) }
+          let(:teacher_id) { existing_period.teacher_id }
+          let(:school_id) { existing_period.school_id }
+          let(:started_on) { existing_period.finished_on - 1.day }
+          let(:finished_on) { started_on + 1.day }
+
+          subject { build(:mentor_at_school_period, teacher_id:, school_id:, started_on:, finished_on:) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Teacher School ECT periods cannot overlap"])
+          end
+        end
+      end
+    end
+
+    context "teacher presence" do
+      context "when the teacher does not exist" do
+        subject { build(:mentor_at_school_period, teacher_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(teacher_id: ["Teacher does not exist"])
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    let!(:teacher) { create(:teacher) }
+    let!(:school) { create(:school) }
+    let!(:school_2) { create(:school) }
+    let!(:period_1) { create(:mentor_at_school_period, teacher:, school:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:mentor_at_school_period, teacher:, school: school_2, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:period_3) { create(:mentor_at_school_period, teacher:, school:, started_on: '2024-01-01', finished_on: nil) }
+    let!(:teacher_2_period) { create(:mentor_at_school_period, school:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+
+    describe ".for_school" do
+      it "returns mentor periods only for the specified school" do
+        expect(described_class.for_school(school_2.id)).to match_array([period_2])
+      end
+    end
+
+    describe ".for_teacher" do
+      it "returns mentor periods only for the specified teacher" do
+        expect(described_class.for_teacher(teacher.id)).to match_array([period_1, period_2, period_3])
+      end
+    end
+
+    describe ".siblings_of" do
+      let!(:mentor_at_school_period) { build(:mentor_at_school_period, teacher:, school:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+
+      it "returns mentor periods only for the specified instance's teacher excluding the instance" do
+        expect(described_class.siblings_of(mentor_at_school_period)).to match_array([period_1, period_2, period_3])
+      end
+    end
+
+    describe ".school_siblings_of" do
+      let!(:mentor_at_school_period) { build(:mentor_at_school_period, teacher:, school: school_2, started_on: "2022-01-01", finished_on: "2023-01-01") }
+
+      it "returns mentor periods for the specified instance's teacher and school excluding the instance" do
+        expect(described_class.school_siblings_of(mentor_at_school_period)).to match_array([period_2])
+      end
+    end
+  end
+end

--- a/spec/models/mentor_at_school_period_spec.rb
+++ b/spec/models/mentor_at_school_period_spec.rb
@@ -52,20 +52,6 @@ describe MentorAtSchoolPeriod do
       end
     end
 
-    context "school presence" do
-      context "when the school does not exist" do
-        subject { build(:mentor_at_school_period, school_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(school_id: ["School does not exist"])
-        end
-      end
-    end
-
     context "teacher school distinct period" do
       context "when the period has not finished yet" do
         context "when the teacher has a school sibling mentor_at_school_period starting later" do
@@ -103,20 +89,6 @@ describe MentorAtSchoolPeriod do
           it "add an error" do
             expect(subject.errors.messages).to include(base: ["Teacher School ECT periods cannot overlap"])
           end
-        end
-      end
-    end
-
-    context "teacher presence" do
-      context "when the teacher does not exist" do
-        subject { build(:mentor_at_school_period, teacher_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(teacher_id: ["Teacher does not exist"])
         end
       end
     end

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -1,0 +1,121 @@
+describe MentorshipPeriod do
+  describe "associations" do
+    it { is_expected.to belong_to(:mentee).class_name("ECTAtSchoolPeriod").with_foreign_key(:ect_at_school_period_id).inverse_of(:mentorship_periods) }
+    it { is_expected.to belong_to(:mentor).class_name("MentorAtSchoolPeriod").with_foreign_key(:mentor_at_school_period_id).inverse_of(:mentorship_periods) }
+  end
+
+  describe "validations" do
+    subject { create(:mentorship_period) }
+
+    it {
+      is_expected.to validate_uniqueness_of(:finished_on)
+                       .scoped_to(:ect_at_school_period_id)
+                       .allow_nil
+                       .with_message("matches the end date of an existing period for mentee")
+    }
+    it {
+      is_expected.to validate_uniqueness_of(:started_on)
+                       .scoped_to(:ect_at_school_period_id)
+                       .with_message("matches the start date of an existing period for mentee")
+    }
+    it { is_expected.to validate_presence_of(:started_on) }
+    it { is_expected.to validate_presence_of(:ect_at_school_period_id) }
+    it { is_expected.to validate_presence_of(:mentor_at_school_period_id) }
+
+    context "mentee presence" do
+      context "when the mentee does not exist" do
+        subject { build(:mentorship_period, ect_at_school_period_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(ect_at_school_period_id: ["Mentee does not exist"])
+        end
+      end
+    end
+
+    context "mentor presence" do
+      context "when the mentor does not exist" do
+        subject { build(:mentorship_period, mentor_at_school_period_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(mentor_at_school_period_id: ["Mentor does not exist"])
+        end
+      end
+    end
+
+    context "mentee distinct period" do
+      context "when the period has not finished yet" do
+        context "when the mentee has a sibling mentorship periods starting later" do
+          let!(:existing_period) { create(:mentorship_period) }
+          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
+          let(:started_on) { existing_period.started_on - 1.year }
+
+          subject { build(:mentorship_period, ect_at_school_period_id:, started_on:, finished_on: nil) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Mentee periods cannot overlap"])
+          end
+        end
+      end
+
+      context "when the period has end date" do
+        context "when the mentee has a sibling mentorship_period overlapping" do
+          let!(:existing_period) { create(:mentorship_period) }
+          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
+          let(:started_on) { existing_period.finished_on - 1.day }
+          let(:finished_on) { started_on + 1.day }
+
+          subject { build(:mentorship_period, ect_at_school_period_id:, started_on:, finished_on:) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Mentee periods cannot overlap"])
+          end
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    let!(:mentee) { create(:ect_at_school_period) }
+    let!(:mentor) { create(:mentor_at_school_period) }
+    let!(:period_1) { create(:mentorship_period, mentee:, mentor:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:mentorship_period, mentee:, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:period_3) { create(:mentorship_period, mentee:, mentor:, started_on: '2024-01-01', finished_on: nil) }
+    let!(:mentee_2_period) { create(:mentorship_period, mentor:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+
+    describe ".for_mentee" do
+      it "returns mentorship periods only for the specified mentee" do
+        expect(described_class.for_mentee(mentee.id)).to match_array([period_1, period_2, period_3])
+      end
+    end
+
+    describe ".for_mentor" do
+      it "returns mentorship periods only for the specified mentor" do
+        expect(described_class.for_mentor(mentor.id)).to match_array([period_1, period_3, mentee_2_period])
+      end
+    end
+
+    describe ".mentee_siblings_of" do
+      let(:mentorship_period) { build(:mentorship_period, mentee:, mentor:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+
+      it "returns mentorship periods only for the specified instance's mentee excluding the instance" do
+        expect(described_class.mentee_siblings_of(mentorship_period)).to match_array([period_1, period_2, period_3])
+      end
+    end
+  end
+end

--- a/spec/models/mentorship_period_spec.rb
+++ b/spec/models/mentorship_period_spec.rb
@@ -22,34 +22,6 @@ describe MentorshipPeriod do
     it { is_expected.to validate_presence_of(:ect_at_school_period_id) }
     it { is_expected.to validate_presence_of(:mentor_at_school_period_id) }
 
-    context "mentee presence" do
-      context "when the mentee does not exist" do
-        subject { build(:mentorship_period, ect_at_school_period_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(ect_at_school_period_id: ["Mentee does not exist"])
-        end
-      end
-    end
-
-    context "mentor presence" do
-      context "when the mentor does not exist" do
-        subject { build(:mentorship_period, mentor_at_school_period_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(mentor_at_school_period_id: ["Mentor does not exist"])
-        end
-      end
-    end
-
     context "mentee distinct period" do
       context "when the period has not finished yet" do
         context "when the mentee has a sibling mentorship periods starting later" do

--- a/spec/models/provider_partnership_spec.rb
+++ b/spec/models/provider_partnership_spec.rb
@@ -1,0 +1,108 @@
+describe ProviderPartnership do
+  describe "associations" do
+    it { is_expected.to belong_to(:academic_year).inverse_of(:provider_partnerships) }
+    it { is_expected.to belong_to(:lead_provider).inverse_of(:provider_partnerships) }
+    it { is_expected.to belong_to(:delivery_partner).inverse_of(:provider_partnerships) }
+  end
+
+  describe "validations" do
+    subject { create(:provider_partnership) }
+
+    it { is_expected.to validate_presence_of(:academic_year_id) }
+    it { is_expected.to validate_presence_of(:lead_provider_id) }
+    it { is_expected.to validate_presence_of(:delivery_partner_id) }
+
+    context "uniqueness of academic_year scoped to lead_provider_id and delivery_partner_id" do
+      context "when the provider partnership matches the lead_provider_id, delivery_partner_id and academic_year values
+               of an existing provider partnership" do
+        let!(:existing_partnership) { create(:provider_partnership) }
+        let(:academic_year_id) { existing_partnership.academic_year_id }
+        let(:lead_provider_id) { existing_partnership.lead_provider_id }
+        let(:delivery_partner_id) { existing_partnership.delivery_partner_id }
+
+        subject { build(:provider_partnership, academic_year_id:, lead_provider_id:, delivery_partner_id:) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(academic_year_id: ["has already been added"])
+        end
+      end
+    end
+
+    context "academic_year presence" do
+      context "when the academic_year does not exist" do
+        subject { build(:provider_partnership, academic_year_id: rand(2021..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(academic_year_id: ["Academic year not registered"])
+        end
+      end
+    end
+
+    context "lead provider presence" do
+      context "when the lead provider does not exist" do
+        subject { build(:provider_partnership, lead_provider_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(lead_provider_id: ["Lead provider not registered"])
+        end
+      end
+    end
+
+    context "delivery partner presence" do
+      context "when the delivery partner does not exist" do
+        subject { build(:provider_partnership, delivery_partner_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(delivery_partner_id: ["Delivery partner not registered"])
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    let!(:ay_1) { create(:academic_year) }
+    let!(:ay_2) { create(:academic_year) }
+    let!(:lp_1) { create(:lead_provider) }
+    let!(:lp_2) { create(:lead_provider) }
+    let!(:dp_1) { create(:delivery_partner) }
+    let!(:dp_2) { create(:delivery_partner) }
+    let!(:partnership_1) { create(:provider_partnership, academic_year: ay_1, lead_provider: lp_1, delivery_partner: dp_1) }
+    let!(:partnership_2) { create(:provider_partnership, academic_year: ay_1, lead_provider: lp_1, delivery_partner: dp_2) }
+    let!(:partnership_3) { create(:provider_partnership, academic_year: ay_1, lead_provider: lp_2, delivery_partner: dp_1) }
+    let!(:partnership_4) { create(:provider_partnership, academic_year: ay_2, lead_provider: lp_1, delivery_partner: dp_2) }
+
+    describe ".for_academic_year" do
+      it "returns provider partnerships only for the specified academic year" do
+        expect(described_class.for_academic_year(ay_1.id)).to match_array([partnership_1, partnership_2, partnership_3])
+      end
+    end
+
+    describe ".for_lead_provider" do
+      it "returns provider partnerships only for the specified lead provider" do
+        expect(described_class.for_lead_provider(lp_2.id)).to match_array([partnership_3])
+      end
+    end
+
+    describe ".for_delivery_partner" do
+      it "returns provider partnerships only for the specified delivery partner" do
+        expect(described_class.for_delivery_partner(dp_1.id)).to match_array([partnership_1, partnership_3])
+      end
+    end
+  end
+end

--- a/spec/models/provider_partnership_spec.rb
+++ b/spec/models/provider_partnership_spec.rb
@@ -31,48 +31,6 @@ describe ProviderPartnership do
         end
       end
     end
-
-    context "academic_year presence" do
-      context "when the academic_year does not exist" do
-        subject { build(:provider_partnership, academic_year_id: rand(2021..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(academic_year_id: ["Academic year not registered"])
-        end
-      end
-    end
-
-    context "lead provider presence" do
-      context "when the lead provider does not exist" do
-        subject { build(:provider_partnership, lead_provider_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(lead_provider_id: ["Lead provider not registered"])
-        end
-      end
-    end
-
-    context "delivery partner presence" do
-      context "when the delivery partner does not exist" do
-        subject { build(:provider_partnership, delivery_partner_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(delivery_partner_id: ["Delivery partner not registered"])
-        end
-      end
-    end
   end
 
   describe "scopes" do

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -1,0 +1,12 @@
+describe School do
+  describe "associations" do
+    it { is_expected.to have_many(:ect_at_school_periods) }
+    it { is_expected.to have_many(:mentor_at_school_periods) }
+  end
+
+  describe "validations" do
+    subject { build(:teacher) }
+
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -1,0 +1,12 @@
+describe Teacher do
+  describe "associations" do
+    it { is_expected.to have_many(:ect_at_school_periods) }
+    it { is_expected.to have_many(:mentor_at_school_periods) }
+  end
+
+  describe "validations" do
+    subject { build(:teacher) }
+
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -1,0 +1,151 @@
+describe TrainingPeriod do
+  describe "associations" do
+    it { is_expected.to belong_to(:trainee).inverse_of(:training_periods) }
+    it { is_expected.to belong_to(:provider_partnership) }
+    it { is_expected.to have_many(:declarations).inverse_of(:training_period) }
+  end
+
+  describe "validations" do
+    subject { create(:training_period) }
+
+    it { is_expected.to validate_presence_of(:started_on) }
+    it { is_expected.to validate_presence_of(:trainee_id) }
+    it { is_expected.to validate_presence_of(:trainee_type) }
+    it { is_expected.to validate_presence_of(:provider_partnership_id) }
+
+    context "uniqueness of finished_on scoped to trainee_id and trainee_type" do
+      context "when the period matches the trainee_id, trainee_type and finished_on values of an existing training period" do
+        let!(:existing_period) { create(:training_period) }
+        let(:finished_on) { existing_period.finished_on }
+        let(:started_on) { existing_period.finished_on - 1.day }
+        let(:trainee_id) { existing_period.trainee_id }
+        let(:trainee_type) { existing_period.trainee_type }
+
+        subject { build(:training_period, trainee_id:, trainee_type:, started_on:, finished_on:) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(finished_on: ["matches the end date of an existing period for trainee"])
+        end
+      end
+    end
+
+    context "uniqueness of started_on scoped to trainee_id and trainee_type" do
+      context "when the period matches the trainee_id, trainee_type and started_on values of an existing training period" do
+        let!(:existing_period) { create(:training_period) }
+        let(:started_on) { existing_period.started_on }
+        let(:trainee_id) { existing_period.trainee_id }
+        let(:trainee_type) { existing_period.trainee_type }
+
+        subject { build(:training_period, trainee_id:, trainee_type:, started_on:) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(started_on: ["matches the start date of an existing period for trainee"])
+        end
+      end
+    end
+
+    context "trainee presence" do
+      context "when the trainee does not exist" do
+        subject { build(:training_period, trainee_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(trainee_id: ["Trainee not registered"])
+        end
+      end
+    end
+
+    context "provider partnership presence" do
+      context "when the provicer partnership does not exist" do
+        subject { build(:training_period, provider_partnership_id: rand(1000..9999)) }
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(provider_partnership_id: ["Provider partnership not registered"])
+        end
+      end
+    end
+
+    context "trainee distinct period" do
+      context "when the period has not finished yet" do
+        context "when the trainee has a sibling training period starting later" do
+          let!(:existing_period) { create(:training_period) }
+          let(:trainee) { existing_period.trainee }
+          let(:started_on) { existing_period.started_on - 1.year }
+
+          subject { build(:training_period, trainee:, started_on:, finished_on: nil) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Trainee periods cannot overlap"])
+          end
+        end
+      end
+
+      context "when the period has end date" do
+        context "when the trainee has a sibling training period overlapping" do
+          let!(:existing_period) { create(:training_period) }
+          let(:trainee) { existing_period.trainee }
+          let(:started_on) { existing_period.finished_on - 1.day }
+          let(:finished_on) { started_on + 1.day }
+
+          subject { build(:training_period, trainee:, started_on:, finished_on:) }
+
+          before do
+            subject.valid?
+          end
+
+          it "add an error" do
+            expect(subject.errors.messages).to include(base: ["Trainee periods cannot overlap"])
+          end
+        end
+      end
+    end
+  end
+
+  describe "scopes" do
+    let!(:trainee) { create(:ect_at_school_period) }
+    let!(:provider_partnership) { create(:provider_partnership) }
+    let!(:period_1) { create(:training_period, trainee:, provider_partnership:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:training_period, trainee:, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:period_3) { create(:training_period, trainee:, provider_partnership:, started_on: '2024-01-01', finished_on: nil) }
+    let!(:trainee_2_period) { create(:training_period, provider_partnership:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+
+    describe ".for_trainee" do
+      it "returns training periods only for the specified trainee" do
+        expect(described_class.for_trainee(trainee.id, trainee.class.name)).to match_array([period_1, period_2, period_3])
+      end
+    end
+
+    describe ".for_provider_partnership" do
+      it "returns training periods only for the specified provider partnership" do
+        expect(described_class.for_provider_partnership(provider_partnership.id)).to match_array([period_1, period_3, trainee_2_period])
+      end
+    end
+
+    describe ".trainee_siblings_of" do
+      let(:training_period) { build(:training_period, trainee:, provider_partnership:, started_on: "2022-01-01", finished_on: "2023-01-01") }
+
+      it "returns training periods only for the specified instance's trainee excluding the instance" do
+        expect(described_class.trainee_siblings_of(training_period)).to match_array([period_1, period_2, period_3])
+      end
+    end
+  end
+end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -1,6 +1,7 @@
 describe TrainingPeriod do
   describe "associations" do
-    it { is_expected.to belong_to(:trainee).inverse_of(:training_periods) }
+    it { is_expected.to belong_to(:ect_at_school_period).class_name("ECTAtSchoolPeriod").inverse_of(:training_periods) }
+    it { is_expected.to belong_to(:mentor_at_school_period).inverse_of(:training_periods) }
     it { is_expected.to belong_to(:provider_partnership) }
     it { is_expected.to have_many(:declarations).inverse_of(:training_period) }
   end
@@ -9,19 +10,18 @@ describe TrainingPeriod do
     subject { create(:training_period) }
 
     it { is_expected.to validate_presence_of(:started_on) }
-    it { is_expected.to validate_presence_of(:trainee_id) }
-    it { is_expected.to validate_presence_of(:trainee_type) }
     it { is_expected.to validate_presence_of(:provider_partnership_id) }
 
-    context "uniqueness of finished_on scoped to trainee_id and trainee_type" do
-      context "when the period matches the trainee_id, trainee_type and finished_on values of an existing training period" do
+    context "uniqueness of finished_on scoped to trainee ids" do
+      context "when the period matches the ect_at_school_period_id, mentor_at_school_period_id and finished_on values
+               of an existing training period" do
         let!(:existing_period) { create(:training_period) }
         let(:finished_on) { existing_period.finished_on }
         let(:started_on) { existing_period.finished_on - 1.day }
-        let(:trainee_id) { existing_period.trainee_id }
-        let(:trainee_type) { existing_period.trainee_type }
+        let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
+        let(:mentor_at_school_period_id) { existing_period.mentor_at_school_period_id }
 
-        subject { build(:training_period, trainee_id:, trainee_type:, started_on:, finished_on:) }
+        subject { build(:training_period, ect_at_school_period_id:, mentor_at_school_period_id:, started_on:, finished_on:) }
 
         before do
           subject.valid?
@@ -33,14 +33,15 @@ describe TrainingPeriod do
       end
     end
 
-    context "uniqueness of started_on scoped to trainee_id and trainee_type" do
-      context "when the period matches the trainee_id, trainee_type and started_on values of an existing training period" do
+    context "uniqueness of started_on scoped to trainee ids" do
+      context "when the period matches the ect_at_school_period_id, mentor_at_school_period_id and finished_on values
+               of an existing training period" do
         let!(:existing_period) { create(:training_period) }
         let(:started_on) { existing_period.started_on }
-        let(:trainee_id) { existing_period.trainee_id }
-        let(:trainee_type) { existing_period.trainee_type }
+        let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
+        let(:mentor_at_school_period_id) { existing_period.mentor_at_school_period_id }
 
-        subject { build(:training_period, trainee_id:, trainee_type:, started_on:) }
+        subject { build(:training_period, ect_at_school_period_id:, mentor_at_school_period_id:, started_on:) }
 
         before do
           subject.valid?
@@ -52,14 +53,54 @@ describe TrainingPeriod do
       end
     end
 
+    context "exactly one id of trainee present" do
+      context "when ect_at_school_period_id and mentor_at_school_period_id are all nil" do
+        let!(:existing_period) { create(:training_period) }
+        let(:started_on) { existing_period.started_on - 1.year }
+
+        subject do
+          build(:training_period, ect_at_school_period_id: nil, mentor_at_school_period_id: nil, started_on:, finished_on: nil)
+        end
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages[:base]).to include("Id of trainee missing")
+        end
+      end
+
+      context "when ect_at_school_period_id and mentor_at_school_period_id are all set" do
+        let!(:existing_period) { create(:training_period) }
+        let(:started_on) { existing_period.started_on - 1.year }
+
+        subject do
+          build(:training_period,
+                ect_at_school_period_id: 200,
+                mentor_at_school_period_id: 300,
+                started_on:,
+                finished_on: nil)
+        end
+
+        before do
+          subject.valid?
+        end
+
+        it "add an error" do
+          expect(subject.errors.messages).to include(base: ["Only one id of trainee required. Two given"])
+        end
+      end
+    end
+
     context "trainee distinct period" do
       context "when the period has not finished yet" do
         context "when the trainee has a sibling training period starting later" do
           let!(:existing_period) { create(:training_period) }
-          let(:trainee) { existing_period.trainee }
+          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
           let(:started_on) { existing_period.started_on - 1.year }
 
-          subject { build(:training_period, trainee:, started_on:, finished_on: nil) }
+          subject { build(:training_period, ect_at_school_period_id:, started_on:, finished_on: nil) }
 
           before do
             subject.valid?
@@ -74,18 +115,18 @@ describe TrainingPeriod do
       context "when the period has end date" do
         context "when the trainee has a sibling training period overlapping" do
           let!(:existing_period) { create(:training_period) }
-          let(:trainee) { existing_period.trainee }
+          let(:ect_at_school_period_id) { existing_period.ect_at_school_period_id }
           let(:started_on) { existing_period.finished_on - 1.day }
           let(:finished_on) { started_on + 1.day }
 
-          subject { build(:training_period, trainee:, started_on:, finished_on:) }
+          subject { build(:training_period, ect_at_school_period_id:, started_on:, finished_on:) }
 
           before do
             subject.valid?
           end
 
           it "add an error" do
-            expect(subject.errors.messages).to include(base: ["Trainee periods cannot overlap"])
+            expect(subject.errors.messages[:base]).to include("Trainee periods cannot overlap")
           end
         end
       end
@@ -93,30 +134,41 @@ describe TrainingPeriod do
   end
 
   describe "scopes" do
-    let!(:trainee) { create(:ect_at_school_period) }
+    let!(:ect_at_school_period) { create(:ect_at_school_period) }
+    let!(:mentor_at_school_period) { create(:mentor_at_school_period) }
     let!(:provider_partnership) { create(:provider_partnership) }
-    let!(:period_1) { create(:training_period, trainee:, provider_partnership:, started_on: '2023-01-01', finished_on: '2023-06-01') }
-    let!(:period_2) { create(:training_period, trainee:, started_on: "2023-06-01", finished_on: "2024-01-01") }
-    let!(:period_3) { create(:training_period, trainee:, provider_partnership:, started_on: '2024-01-01', finished_on: nil) }
-    let!(:trainee_2_period) { create(:training_period, provider_partnership:, started_on: '2023-02-01', finished_on: '2023-07-01') }
+    let!(:period_1) { create(:training_period, :for_ect, ect_at_school_period:, provider_partnership:, started_on: '2023-01-01', finished_on: '2023-06-01') }
+    let!(:period_2) { create(:training_period, :for_ect, ect_at_school_period:, started_on: "2023-06-01", finished_on: "2024-01-01") }
+    let!(:period_3) { create(:training_period, :for_ect, ect_at_school_period:, provider_partnership:, started_on: '2024-01-01', finished_on: nil) }
+    let!(:period_4) { create(:training_period, :for_mentor, mentor_at_school_period:, provider_partnership:, started_on: '2023-02-01', finished_on: '2023-07-01') }
 
-    describe ".for_trainee" do
-      it "returns training periods only for the specified trainee" do
-        expect(described_class.for_trainee(trainee.id, trainee.class.name)).to match_array([period_1, period_2, period_3])
+    describe ".for_ect" do
+      it "returns training periods only for the specified ect_at_school_period_id" do
+        expect(described_class.for_ect(ect_at_school_period.id)).to match_array([period_1, period_2, period_3])
+      end
+    end
+
+    describe ".for_mentor" do
+      it "returns training periods only for the specified mentor_at_school_period_id" do
+        expect(described_class.for_mentor(mentor_at_school_period.id)).to match_array([period_4])
       end
     end
 
     describe ".for_provider_partnership" do
       it "returns training periods only for the specified provider partnership" do
-        expect(described_class.for_provider_partnership(provider_partnership.id)).to match_array([period_1, period_3, trainee_2_period])
+        expect(described_class.for_provider_partnership(provider_partnership.id)).to match_array([period_1, period_3, period_4])
       end
     end
 
     describe ".trainee_siblings_of" do
-      let(:training_period) { build(:training_period, trainee:, provider_partnership:, started_on: "2022-01-01", finished_on: "2023-01-01") }
-
       it "returns training periods only for the specified instance's trainee excluding the instance" do
-        expect(described_class.trainee_siblings_of(training_period)).to match_array([period_1, period_2, period_3])
+        expect(described_class.trainee_siblings_of(period_3)).to match_array([period_1, period_2])
+      end
+
+      context "when there are no siblings" do
+        it "returns an empty list" do
+          expect(described_class.trainee_siblings_of(period_4)).to match_array([])
+        end
       end
     end
   end

--- a/spec/models/training_period_spec.rb
+++ b/spec/models/training_period_spec.rb
@@ -52,34 +52,6 @@ describe TrainingPeriod do
       end
     end
 
-    context "trainee presence" do
-      context "when the trainee does not exist" do
-        subject { build(:training_period, trainee_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(trainee_id: ["Trainee not registered"])
-        end
-      end
-    end
-
-    context "provider partnership presence" do
-      context "when the provicer partnership does not exist" do
-        subject { build(:training_period, provider_partnership_id: rand(1000..9999)) }
-
-        before do
-          subject.valid?
-        end
-
-        it "add an error" do
-          expect(subject.errors.messages).to include(provider_partnership_id: ["Provider partnership not registered"])
-        end
-      end
-    end
-
     context "trainee distinct period" do
       context "when the period has not finished yet" do
         context "when the trainee has a sibling training period starting later" do

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
This PR introduces the draft data model from the [ECF2 Rails Prototype](https://github.com/DFE-Digital/ecf2-rails-prototype) and begins the GIAS data import process.

![image](https://github.com/user-attachments/assets/02de76cf-b0c1-4b43-8f12-57fb0cae4188)


## Decisions

* for now, we think moving the eligibility statuses to attributes on `School` and recalculating them whenever the GIAS school updates

## Remaining tasks

* [x] Add specs for the new models covering their relationships
* [x] Add validation to the models and test it - ensure the unique indexes are covered by Rails equivalents too
* [x] Add some enums to the models for the introduced enumerated database types
* [x] ~~Add services to calculate eligibility based on the rules~~ @mason-emily created in #125 - do this separately, it's probably going to be tricky


Refs #2, #9