### PR TITLE
Add terraform linting step to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -101,3 +101,29 @@ jobs:
         if: false
         run: |-
           bundle exec erblint --lint-all
+
+  terraform_linting:
+    name: Lint Terraform
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout Code
+
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.5
+
+      - name: Check formatting
+        run: terraform fmt -check -recursive -diff
+        working-directory: config/terraform
+
+      - name: Download vendor modules
+        run: make ci staging bin/terrafile
+
+      - name: Validate
+        run: |
+          terraform init -backend=false
+          terraform validate -no-color
+        working-directory: config/terraform/application

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -126,4 +126,3 @@ jobs:
         run: |
           terraform init -backend=false
           terraform validate -no-color
-        working-directory: config/terraform/application


### PR DESCRIPTION
This change was suggested by @saliceti and is based on [the implementation from Apply For QTS](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/.github/workflows/lint.yml#L34)

It uses `terraform fmt` and `terraform validate` to check the files are formatted properly.

Unlike Apply for QTS, who have a deployed `development` environment, we're using `staging`. As a result this relies on #143.

I've run these steps manually and they work. `terraform fmt` shows some suggested fixes but it's probably not worth fixing them yet.

~~Also @steventux, is it worth pointing this PR at #143 and rebasing the others to save applying the adjustments afterwards?~~
