### PR TITLE
Only deploy review apps on PRs explicitly labelled with 'deploy'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
   deploy-review:
     name: Deploy review
     concurrency: deploy_review_${{ github.event.pull_request.number }}
-    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy')
     needs: [docker]
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
Amends the github deploy workflow to detect the presence of the label 'deploy' before creating a review app deployment.
Every little helps.
