### PR TITLE
Add the fields needed for AB data submission

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -27,10 +27,11 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11.6-alpine
+        image: postgres:16.4-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: ""
+          POSTGRES_HOST_AUTH_METHOD: "trust"
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,3 +38,6 @@ Style/SignalException:
 
 Style/StringConcatenation:
   Enabled: false
+
+Rails/UniqueValidationWithoutIndex:
+  Enabled: false

--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -6,4 +6,22 @@ class AppropriateBody < ApplicationRecord
   validates :name,
             presence: true,
             uniqueness: true
+
+  validates :local_authority_code,
+            presence: { message: 'Enter a local authority code' },
+            inclusion: {
+              in: 100..999,
+              message: 'Must be a number between 100 and 999'
+            },
+            uniqueness: {
+              scope: :establishment_number,
+              message: "An appropriate body with this local authority code and establishment number already exists"
+            }
+
+  validates :establishment_number,
+            presence: { message: 'Enter a establishment number' },
+            inclusion: {
+              in: 1000..9999,
+              message: 'Must be a number between 1000 and 9999'
+            }
 end

--- a/app/models/appropriate_body.rb
+++ b/app/models/appropriate_body.rb
@@ -1,5 +1,6 @@
 class AppropriateBody < ApplicationRecord
   # Associations
+  has_many :pending_induction_submissions
   has_many :induction_periods, inverse_of: :appropriate_body
 
   # Validations

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -22,6 +22,14 @@ class InductionPeriod < ApplicationRecord
   validates :ect_at_school_period_id,
             presence: true
 
+  validates :number_of_terms,
+            presence: { message: "Enter a number of terms",
+                        if: -> { finished_on.present? } }
+
+  validates :induction_programme,
+            inclusion: { in: %w[fip cip diy],
+                         message: "Choose an induction programme" }
+
   validate :teacher_distinct_period
 
   # Scopes

--- a/app/models/pending_induction_submission.rb
+++ b/app/models/pending_induction_submission.rb
@@ -1,0 +1,30 @@
+# PendingInductionSubmission will contain data submitted by appropriate bodies
+# containing induction information about a ECT.
+#
+# It is intended to be a short-lived record that we will process, verify and
+# eventually write to the actual database before deleting the record here.
+class PendingInductionSubmission < ApplicationRecord
+  include Interval
+
+  # Associations
+  belongs_to :appropriate_body
+
+  # Validations
+  validates :trn,
+            format: { with: Teacher::TRN_FORMAT, message: "TRN must be 7 numeric digits" }
+
+  validates :establishment_id,
+            format: { with: /\A\d{4}\/\d{3}\z/, message: "Enter an establishment ID in the format 1234/567" },
+            allow_nil: true
+
+  validates :induction_programme,
+            inclusion: { in: %w[fip cip diy],
+                         message: "Choose an induction programme" }
+
+  validates :date_of_birth,
+            inclusion: { in: 100.years.ago..18.years.ago }
+
+  validates :number_of_terms,
+            inclusion: { in: 0..16,
+                         message: "Terms must be between 0 and 16" }
+end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -1,4 +1,6 @@
 class Teacher < ApplicationRecord
+  TRN_FORMAT = %r{\A\d{7}\z}
+
   # Associations
   has_many :ect_at_school_periods, inverse_of: :teacher
   has_many :mentor_at_school_periods, inverse_of: :teacher
@@ -6,4 +8,8 @@ class Teacher < ApplicationRecord
   # Validations
   validates :name,
             presence: true
+
+  validates :trn,
+            format: { with: TRN_FORMAT, message: "TRN must be 7 numeric digits" },
+            uniqueness: { message: 'TRN already exists', case_sensitive: false }
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,4 +16,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "API"
   inflect.acronym "GIAS"
   inflect.acronym "OTP"
+  inflect.acronym "TRN"
 end

--- a/db/migrate/20240904125324_add_establishment_and_la_fields_to_abs.rb
+++ b/db/migrate/20240904125324_add_establishment_and_la_fields_to_abs.rb
@@ -1,0 +1,10 @@
+class AddEstablishmentAndLaFieldsToAbs < ActiveRecord::Migration[7.2]
+  def change
+    # rubocop:disable Rails/NotNullColumn, Rails/BulkChangeTable
+    add_column :appropriate_bodies, :local_authority_code, :integer, null: false
+    add_column :appropriate_bodies, :establishment_number, :integer, null: false
+    add_column :appropriate_bodies, :establishment_id, :virtual, type: :string, as: %(local_authority_code::varchar || '/' || establishment_number::varchar), stored: true
+    add_index :appropriate_bodies, %i[local_authority_code establishment_number], unique: true
+    # rubocop:enable Rails/NotNullColumn, Rails/BulkChangeTable
+  end
+end

--- a/db/migrate/20240905133533_add_trn_to_teachers.rb
+++ b/db/migrate/20240905133533_add_trn_to_teachers.rb
@@ -1,0 +1,8 @@
+class AddTRNToTeachers < ActiveRecord::Migration[7.2]
+  def change
+    # rubocop:disable Rails/NotNullColumn
+    add_column :teachers, :trn, :string, null: false
+    add_index :teachers, :trn, unique: true
+    # rubocop:enable Rails/NotNullColumn
+  end
+end

--- a/db/migrate/20240906122532_add_induction_programme_to_induction_periods.rb
+++ b/db/migrate/20240906122532_add_induction_programme_to_induction_periods.rb
@@ -1,0 +1,12 @@
+class AddInductionProgrammeToInductionPeriods < ActiveRecord::Migration[7.2]
+  def change
+    create_enum :induction_programme, %w[cip fip diy]
+
+    change_table :induction_periods do |t|
+      # rubocop:disable Rails/NotNullColumn
+      t.enum :induction_programme, null: false, enum_type: :induction_programme
+      t.integer :number_of_terms, null: true
+      # rubocop:enable Rails/NotNullColumn
+    end
+  end
+end

--- a/db/migrate/20240906140850_create_pending_induction_submissions.rb
+++ b/db/migrate/20240906140850_create_pending_induction_submissions.rb
@@ -1,0 +1,18 @@
+class CreatePendingInductionSubmissions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :pending_induction_submissions do |t|
+      t.references :appropriate_body, null: true, foreign_key: true
+      t.string :establishment_id, limit: 8, null: true
+      t.string :trn, null: false, limit: 7
+      t.string :first_name, limit: 80
+      t.string :last_name, limit: 80
+      t.date :date_of_birth
+      t.string :induction_status, limit: 16
+      t.enum :induction_programme, enum_type: :induction_programme, null: false
+      t.date :started_on
+      t.date :finished_on
+      t.integer :number_of_terms
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -282,7 +282,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_05_183321) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "trn", null: false
     t.index ["name"], name: "index_teachers_on_name"
+    t.index ["trn"], name: "index_teachers_on_trn", unique: true
   end
 
   create_table "training_periods", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_06_122532) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_06_140850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -137,6 +137,23 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_06_122532) do
     t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
     t.index ["mentor_at_school_period_id", "ect_at_school_period_id", "started_on"], name: "idx_on_mentor_at_school_period_id_ect_at_school_per_d69dffeecc", unique: true
     t.index ["mentor_at_school_period_id"], name: "index_mentorship_periods_on_mentor_at_school_period_id"
+  end
+
+  create_table "pending_induction_submissions", force: :cascade do |t|
+    t.bigint "appropriate_body_id"
+    t.string "establishment_id", limit: 8
+    t.string "trn", limit: 7, null: false
+    t.string "first_name", limit: 80
+    t.string "last_name", limit: 80
+    t.date "date_of_birth"
+    t.string "induction_status", limit: 16
+    t.enum "induction_programme", null: false, enum_type: "induction_programme"
+    t.date "started_on"
+    t.date "finished_on"
+    t.integer "number_of_terms"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["appropriate_body_id"], name: "index_pending_induction_submissions_on_appropriate_body_id"
   end
 
   create_table "provider_partnerships", force: :cascade do |t|
@@ -324,6 +341,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_06_122532) do
   add_foreign_key "mentor_at_school_periods", "teachers"
   add_foreign_key "mentorship_periods", "ect_at_school_periods"
   add_foreign_key "mentorship_periods", "mentor_at_school_periods"
+  add_foreign_key "pending_induction_submissions", "appropriate_bodies"
   add_foreign_key "provider_partnerships", "academic_years", primary_key: "year"
   add_foreign_key "provider_partnerships", "delivery_partners"
   add_foreign_key "provider_partnerships", "lead_providers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_05_183321) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "local_authority_code", null: false
+    t.integer "establishment_number", null: false
+    t.virtual "establishment_id", type: :string, as: "((((local_authority_code)::character varying)::text || '/'::text) || ((establishment_number)::character varying)::text)", stored: true
+    t.index ["local_authority_code", "establishment_number"], name: "idx_on_local_authority_code_establishment_number_039c79cd09", unique: true
     t.index ["name"], name: "index_appropriate_bodies_on_name", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_05_183321) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_06_122532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_05_183321) do
   create_enum "funding_eligibility_status", ["eligible_for_fip", "eligible_for_cip", "ineligible"]
   create_enum "gias_school_statuses", ["open", "closed", "proposed_to_close", "proposed_to_open"]
   create_enum "induction_eligibility_status", ["eligible", "ineligible"]
+  create_enum "induction_programme", ["cip", "fip", "diy"]
 
   create_table "academic_years", primary_key: "year", id: :serial, force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -95,6 +96,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_05_183321) do
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.enum "induction_programme", null: false, enum_type: "induction_programme"
+    t.integer "number_of_terms"
     t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_be6c214e9d", unique: true, where: "(finished_on IS NULL)"
     t.index ["appropriate_body_id"], name: "index_induction_periods_on_appropriate_body_id"
     t.index ["ect_at_school_period_id", "started_on"], name: "index_induction_periods_on_ect_at_school_period_id_started_on", unique: true

--- a/spec/factories/appropriate_body_factory.rb
+++ b/spec/factories/appropriate_body_factory.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory(:appropriate_body) do
     name { "#{Faker::Lorem.word.capitalize} AB" }
+    sequence(:local_authority_code, 100)
+    sequence(:establishment_number, 1000)
   end
 end

--- a/spec/factories/induction_period_factory.rb
+++ b/spec/factories/induction_period_factory.rb
@@ -7,9 +7,15 @@ FactoryBot.define do
 
     started_on { generate(:base_induction_date) }
     finished_on { started_on + 3.months }
+    number_of_terms { Faker::Number.within(range: 1..6) }
+    induction_programme { "fip" }
 
     trait :active do
       finished_on { nil }
+      number_of_terms { nil }
     end
+
+    trait(:cip) { induction_programme { "cip" } }
+    trait(:diy) { induction_programme { "diy" } }
   end
 end

--- a/spec/factories/teacher_factory.rb
+++ b/spec/factories/teacher_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory(:teacher) do
+    sequence(:trn, 1_000_000)
     name { [Faker::Name.name, Faker::Name.last_name].join(" ") }
   end
 end

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -1,6 +1,7 @@
 describe AppropriateBody do
   describe "associations" do
     it { is_expected.to have_many(:induction_periods) }
+    it { is_expected.to have_many(:pending_induction_submissions) }
   end
 
   describe "validations" do

--- a/spec/models/appropriate_body_spec.rb
+++ b/spec/models/appropriate_body_spec.rb
@@ -8,5 +8,31 @@ describe AppropriateBody do
 
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_uniqueness_of(:name) }
+
+    it { is_expected.to validate_presence_of(:local_authority_code).with_message('Enter a local authority code') }
+    it { is_expected.to validate_inclusion_of(:local_authority_code).in_range(100..999).with_message('Must be a number between 100 and 999') }
+
+    it { is_expected.to validate_presence_of(:establishment_number).with_message('Enter a establishment number') }
+    it { is_expected.to validate_inclusion_of(:establishment_number).in_range(1000..9999).with_message('Must be a number between 1000 and 9999') }
+
+    it "ensures local_authority_code and establishment_number are unique in combination" do
+      ab_args = { local_authority_code: 123, establishment_number: 4567 }
+      FactoryBot.create(:appropriate_body, name: "AB1", **ab_args)
+      FactoryBot.build(:appropriate_body, name: "AB2", **ab_args).tap do |duplicate_ab|
+        expect(duplicate_ab).to be_invalid
+        expect(duplicate_ab.errors.messages.fetch(:local_authority_code)).to include(/local authority code and establishment number already exists/)
+      end
+    end
+  end
+
+  describe '#establishment_id' do
+    let(:local_authority_code) { 123 }
+    let(:establishment_number) { 4567 }
+
+    subject { FactoryBot.create(:appropriate_body, local_authority_code:, establishment_number:) }
+
+    it "is the local_authority_code and establishment_number separated by a '/'" do
+      expect(subject.establishment_id).to eql("#{local_authority_code}/#{establishment_number}")
+    end
   end
 end

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -22,7 +22,7 @@ describe InductionPeriod do
     it { is_expected.to validate_presence_of(:appropriate_body_id) }
     it { is_expected.to validate_presence_of(:ect_at_school_period_id) }
 
-    context "teacher distinct period" do
+    describe "teacher distinct period" do
       context "when the period has not finished yet" do
         context "when the ect has a sibling induction period starting later" do
           let!(:existing_period) { FactoryBot.create(:induction_period) }
@@ -58,6 +58,20 @@ describe InductionPeriod do
             expect(subject.errors.messages).to include(base: ["Teacher induction periods cannot overlap"])
           end
         end
+      end
+    end
+
+    it { is_expected.to validate_inclusion_of(:induction_programme).in_array(%w[fip cip diy]).with_message("Choose an induction programme") }
+
+    describe "number_of_terms" do
+      context "when finished_on is empty" do
+        subject { FactoryBot.build(:induction_period, finished_on: nil) }
+        it { is_expected.not_to validate_presence_of(:number_of_terms) }
+      end
+
+      context "when finished_on is present" do
+        subject { FactoryBot.build(:induction_period, finished_on: Time.zone.today) }
+        it { is_expected.to validate_presence_of(:number_of_terms).with_message("Enter a number of terms") }
       end
     end
   end

--- a/spec/models/pending_induction_submission_spec.rb
+++ b/spec/models/pending_induction_submission_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe PendingInductionSubmission do
+  it { is_expected.to be_a_kind_of(Interval) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:appropriate_body) }
+  end
+
+  describe "validation" do
+    describe "trn" do
+      context "when the string contains 7 numeric digits" do
+        %w[0000001 9999999].each do |value|
+          it { is_expected.to allow_value(value).for(:trn) }
+        end
+      end
+
+      context "when the string contains something other than 7 numeric digits" do
+        %w[123456 12345678 ONE4567 123456!].each do |value|
+          it { is_expected.not_to allow_value(value).for(:trn) }
+        end
+      end
+    end
+
+    describe "establishment_id" do
+      it { is_expected.to allow_value(nil).for(:establishment_id) }
+
+      describe "valid" do
+        ["1111/111", "9999/999"].each do |id|
+          it { is_expected.to allow_value(id).for(:establishment_id) }
+        end
+      end
+
+      describe "invalid" do
+        ["111/1111", "AAAA/BBB", "1234/12345"].each do |id|
+          it { is_expected.not_to allow_value(id).for(:establishment_id).with_message("Enter an establishment ID in the format 1234/567") }
+        end
+      end
+    end
+
+    describe "induction_programme" do
+      it { is_expected.to validate_inclusion_of(:induction_programme).in_array(%w[fip cip diy]).with_message("Choose an induction programme") }
+    end
+
+    describe "number_of_terms" do
+      it { is_expected.to validate_inclusion_of(:number_of_terms).in_range(0..16).with_message("Terms must be between 0 and 16") }
+    end
+  end
+end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -8,5 +8,20 @@ describe Teacher do
     subject { FactoryBot.build(:teacher) }
 
     it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:trn).with_message('TRN already exists').case_insensitive }
+
+    describe "trn" do
+      context "when the string contains 7 numeric digits" do
+        %w[0000001 9999999].each do |value|
+          it { is_expected.to allow_value(value).for(:trn) }
+        end
+      end
+
+      context "when the string contains something other than 7 numeric digits" do
+        %w[123456 12345678 ONE4567 123456!].each do |value|
+          it { is_expected.not_to allow_value(value).for(:trn) }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds the fields and tables suggested in #204  

- **Add AB portal fields to the appropriate_body**
- **Add TRN to teacher model**
- **Add induction programme and number of terms fields**
- **Add pending induction submissions**

I recommend reviewing commit-by-commit as the messages explain the approach.

Fixes #204 