### PR TITLE
Make Playwright a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
         "accessible-autocomplete": "^3.0.0",
         "esbuild": "^0.23.1",
         "govuk-frontend": "5.5.0",
-        "playwright": "^1.47.0",
         "sass": "^1.78.0"
       },
       "devDependencies": {
+        "playwright": "^1.47.0",
         "standard": "^17.1.0",
         "stylelint": "^16.9.0",
         "stylelint-config-gds": "^2.0.0"
@@ -3686,6 +3686,7 @@
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
       "integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
+      "dev": true,
       "dependencies": {
         "playwright-core": "1.47.0"
       },
@@ -3703,6 +3704,7 @@
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
       "integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
+      "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -3714,6 +3716,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
     "accessible-autocomplete": "^3.0.0",
     "esbuild": "^0.23.1",
     "govuk-frontend": "5.5.0",
-    "playwright": "^1.47.0",
     "sass": "^1.78.0"
   },
   "devDependencies": {
+    "playwright": "^1.47.0",
     "standard": "^17.1.0",
     "stylelint": "^16.9.0",
     "stylelint-config-gds": "^2.0.0"


### PR DESCRIPTION
We won't need this in a deployed state, just in CI, so makes sense to shift it.
