### PR TITLE
Upgrade to GOV.UK Frontend 5.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,11 +149,11 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk-components (5.5.0)
+    govuk-components (5.6.1)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
-      view_component (>= 3.9, < 3.14)
-    govuk_design_system_formbuilder (5.5.0)
+      view_component (>= 3.9, < 3.15)
+    govuk_design_system_formbuilder (5.6.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -485,7 +485,7 @@ GEM
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
       public_suffix
-    view_component (3.13.0)
+    view_component (3.14.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -551,4 +551,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.18
+   2.5.17

--- a/app/assets/stylesheets/header/colour-overrides.scss
+++ b/app/assets/stylesheets/header/colour-overrides.scss
@@ -3,9 +3,7 @@ $colours: ("pink", "orange", "red", "purple", "yellow");
 @each $colour in $colours {
   .govuk-header {
     &.app-header--#{$colour} {
-      .govuk-header__container.govuk-width-container {
-        border-color: govuk-colour($colour);
-      }
+      border-color: govuk-colour($colour);
     }
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,12 +6,9 @@
     <%= render partial: "layouts/shared/js_enabled" %>
 
     <%= govuk_skip_link %>
-
-    <%= govuk_header(service_name: "GOV.UK Rails Boilerplate", html_attributes: { class: [environment_specific_header_colour_class] }) do |header| %>
-      <%= header.with_navigation_item(text: "Navigation item 1", href: "#", active: true) %>
-      <%= header.with_navigation_item(text: "Navigation item 2", href: "#") %>
-      <%= header.with_navigation_item(text: "Navigation item 3", href: "#") %>
-      <%= header.with_navigation_item(text: "Sign out", href: sign_out_path) if authenticated? %>
+    <%= govuk_header(full_width_border: true, html_attributes: { class: [environment_specific_header_colour_class] }) %>
+    <%= govuk_service_navigation(service_name: "Register early career teachers") do |service_navigation| %>
+      <%= service_navigation.with_navigation_item(text: "Sign out", href: sign_out_path) if authenticated? %>
     <% end %>
 
     <div class="govuk-width-container">
@@ -19,7 +16,6 @@
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <div class="govuk-grid-row">
-
           <div class="govuk-grid-column-two-thirds">
             <%= yield(:page_header) %>
 

--- a/app/views/layouts/shared/_head.html.erb
+++ b/app/views/layouts/shared/_head.html.erb
@@ -1,5 +1,5 @@
 <head>
-  <%= tag.title([yield(:page_title).presence, "Service name", "GOV.UK"].compact.join(' - ')) %>
+  <%= tag.title([yield(:page_title).presence, "Register early career teachers", "GOV.UK"].compact.join(' - ')) %>
 
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "accessible-autocomplete": "^3.0.0",
         "esbuild": "^0.23.1",
-        "govuk-frontend": "5.5.0",
+        "govuk-frontend": "5.6.0",
         "sass": "^1.78.0"
       },
       "devDependencies": {
@@ -2461,9 +2461,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.5.0.tgz",
-      "integrity": "sha512-lNSHCOzgk6LfgelcdtJxTLK1BX/cpjCUyEB3LnzliD9o9YQckNMsbj5+jSOs2RFy6XBJ/DJqxj2TKfjBCuzpyA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.6.0.tgz",
+      "integrity": "sha512-yNA4bL7i7mNrg36wPNZ3RctHo9mjl82Phs8MWs1lwovxJuQ4ogEo/XWn2uB1HxkXNqgMlW4wnd0iiKgRMfxYfw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "accessible-autocomplete": "^3.0.0",
     "esbuild": "^0.23.1",
-    "govuk-frontend": "5.5.0",
+    "govuk-frontend": "5.6.0",
     "sass": "^1.78.0"
   },
   "devDependencies": {


### PR DESCRIPTION
GOV.UK Frontend 5.6.0 was released last week and introduces the Service navigation component. It's recommended that [the navigation items which formerly sat in the header are moved to the service navigation](https://design-system.service.gov.uk/patterns/navigate-a-service#how-it-works), [along with the service name](https://design-system.service.gov.uk/components/service-navigation#showing-your-service-name-only).

Also, tentatively set a better service name than ECF2. Introducing Register early career teachers.

- **Upgrade govuk-frontend to 5.6.0 and related libs**
- **Move the service name to the service nav**

![Screenshot from 2024-09-08 19-24-02](https://github.com/user-attachments/assets/426f0711-cf0d-4e8c-a31e-b84eb8db75a2)


Fixes #225 