### PR TITLE
Pass docker-image-tag arg to non-prod deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,5 @@ jobs:
         id: deploy
         with:
           environment: ${{ matrix.environment }}
-          docker-image: ${{ needs.docker.outputs.docker-image }}
+          docker-image-tag: ${{ needs.docker.outputs.docker-image-tag }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          current-commit-sha: ${{ github.sha }}


### PR DESCRIPTION
Non production deploys need the `docker-image-tag` argument to specify the correct image tag.
We do this on the deploy-review workflow. Thanks to @saliceti for spotting this.