### PR TITLE
Pass STATUSCAKE_API_TOKEN to deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,3 +94,4 @@ jobs:
           environment: ${{ matrix.environment }}
           docker-image-tag: ${{ needs.docker.outputs.docker-image-tag }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          statuscake-api-token: ${{ secrets.STATUSCAKE_API_TOKEN }}


### PR DESCRIPTION
Part of #7 

We need statuscake to alert us of issues with our deployed environments. Our terraform config already permits the variable `statuscake-api-token` and keyvaults have been populated with the appropriate secret.