### PR TITLE
Use date ranges to check period overlaps

### DIFF
--- a/app/models/concerns/interval.rb
+++ b/app/models/concerns/interval.rb
@@ -8,18 +8,12 @@ module Interval
     # Scopes
     scope :extending_later_than, ->(date) { where("finished_on IS NULL OR finished_on > ?", date) }
     scope :starting_earlier_than, ->(date) { where("started_on < ?", date) }
+    scope :overlapping_with, ->(period) { where("range && daterange(?, ?)", period.started_on, period.finished_on) }
   end
 
   def period_dates_validation
     return if [started_on, finished_on].any?(&:blank?)
 
     errors.add(:finished_on, "Must be later than :started_on") if finished_on <= started_on
-  end
-
-  class_methods do
-    def overlapping(start_date, end_date)
-      scope = extending_later_than(start_date)
-      end_date ? scope.starting_earlier_than(end_date) : scope
-    end
   end
 end

--- a/app/models/ect_at_school_period.rb
+++ b/app/models/ect_at_school_period.rb
@@ -32,7 +32,7 @@ class ECTAtSchoolPeriod < ApplicationRecord
 private
 
   def teacher_distinct_period
-    overlapping_siblings = self.class.siblings_of(self).overlapping(started_on, finished_on).exists?
+    overlapping_siblings = ECTAtSchoolPeriod.siblings_of(self).overlapping_with(self).exists?
     errors.add(:base, "Teacher ECT periods cannot overlap") if overlapping_siblings
   end
 end

--- a/app/models/induction_period.rb
+++ b/app/models/induction_period.rb
@@ -40,7 +40,7 @@ class InductionPeriod < ApplicationRecord
 private
 
   def teacher_distinct_period
-    overlapping_siblings = self.class.siblings_of(self).overlapping(started_on, finished_on).exists?
+    overlapping_siblings = InductionPeriod.siblings_of(self).overlapping_with(self).exists?
     errors.add(:base, "Teacher induction periods cannot overlap") if overlapping_siblings
   end
 end

--- a/app/models/mentor_at_school_period.rb
+++ b/app/models/mentor_at_school_period.rb
@@ -39,7 +39,7 @@ private
   end
 
   def teacher_school_distinct_period
-    overlapping_siblings = self.class.school_siblings_of(self).overlapping(started_on, finished_on).exists?
+    overlapping_siblings = MentorAtSchoolPeriod.school_siblings_of(self).overlapping_with(self).exists?
     errors.add(:base, "Teacher School ECT periods cannot overlap") if overlapping_siblings
   end
 end

--- a/app/models/mentorship_period.rb
+++ b/app/models/mentorship_period.rb
@@ -39,7 +39,7 @@ class MentorshipPeriod < ApplicationRecord
 private
 
   def mentee_distinct_period
-    overlapping_siblings = self.class.mentee_siblings_of(self).overlapping(started_on, finished_on).exists?
+    overlapping_siblings = MentorshipPeriod.mentee_siblings_of(self).overlapping_with(self).exists?
     errors.add(:base, "Mentee periods cannot overlap") if overlapping_siblings
   end
 end

--- a/app/models/training_period.rb
+++ b/app/models/training_period.rb
@@ -54,7 +54,7 @@ private
   end
 
   def trainee_distinct_period
-    overlapping_siblings = self.class.trainee_siblings_of(self).overlapping(started_on, finished_on).exists?
+    overlapping_siblings = TrainingPeriod.trainee_siblings_of(self).overlapping_with(self).exists?
     errors.add(:base, "Trainee periods cannot overlap") if overlapping_siblings
   end
 end

--- a/db/migrate/20240909141258_add_ranges_to_periods.rb
+++ b/db/migrate/20240909141258_add_ranges_to_periods.rb
@@ -1,0 +1,9 @@
+class AddRangesToPeriods < ActiveRecord::Migration[7.2]
+  def change
+    add_column :ect_at_school_periods, :range, :virtual, type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    add_column :induction_periods, :range, :virtual, type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    add_column :mentor_at_school_periods, :range, :virtual, type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    add_column :mentorship_periods, :range, :virtual, type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+    add_column :training_periods, :range, :virtual, type: :daterange, as: "daterange(started_on, finished_on)", stored: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_06_140850) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_09_141258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_06_140850) do
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.index "teacher_id, ((finished_on IS NULL))", name: "index_ect_at_school_periods_on_teacher_id_finished_on_IS_NULL", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "index_ect_at_school_periods_on_school_id_teacher_id_started_on", unique: true
     t.index ["school_id"], name: "index_ect_at_school_periods_on_school_id"
@@ -98,6 +99,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_06_140850) do
     t.datetime "updated_at", null: false
     t.enum "induction_programme", null: false, enum_type: "induction_programme"
     t.integer "number_of_terms"
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_be6c214e9d", unique: true, where: "(finished_on IS NULL)"
     t.index ["appropriate_body_id"], name: "index_induction_periods_on_appropriate_body_id"
     t.index ["ect_at_school_period_id", "started_on"], name: "index_induction_periods_on_ect_at_school_period_id_started_on", unique: true
@@ -118,6 +120,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_06_140850) do
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.index "school_id, teacher_id, ((finished_on IS NULL))", name: "idx_on_school_id_teacher_id_finished_on_IS_NULL_dd7ee16a28", unique: true, where: "(finished_on IS NULL)"
     t.index ["school_id", "teacher_id", "started_on"], name: "idx_on_school_id_teacher_id_started_on_17d46e7783", unique: true
     t.index ["school_id"], name: "index_mentor_at_school_periods_on_school_id"
@@ -132,6 +135,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_06_140850) do
     t.date "finished_on"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.index "ect_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_finished_on_IS_NULL_afd5cf131d", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "started_on"], name: "index_mentorship_periods_on_ect_at_school_period_id_started_on", unique: true
     t.index ["ect_at_school_period_id"], name: "index_mentorship_periods_on_ect_at_school_period_id"
@@ -315,6 +319,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_06_140850) do
     t.datetime "updated_at", null: false
     t.bigint "ect_at_school_period_id"
     t.bigint "mentor_at_school_period_id"
+    t.virtual "range", type: :daterange, as: "daterange(started_on, finished_on)", stored: true
     t.index "ect_at_school_period_id, mentor_at_school_period_id, ((finished_on IS NULL))", name: "idx_on_ect_at_school_period_id_mentor_at_school_per_42bce3bf48", unique: true, where: "(finished_on IS NULL)"
     t.index ["ect_at_school_period_id", "mentor_at_school_period_id", "started_on"], name: "idx_on_ect_at_school_period_id_mentor_at_school_per_70f2bb1a45", unique: true
     t.index ["ect_at_school_period_id"], name: "index_training_periods_on_ect_at_school_period_id"

--- a/spec/models/concerns/interval_spec.rb
+++ b/spec/models/concerns/interval_spec.rb
@@ -1,3 +1,5 @@
+FakePeriod = Struct.new(:started_on, :finished_on)
+
 describe Interval do
   describe "validations" do
     context "period dates" do
@@ -58,17 +60,17 @@ describe Interval do
       end
     end
 
-    describe ".overlapping" do
+    describe ".overlapping_with" do
       it "returns periods overlapping with the specified date range" do
-        expect(DummyMentor.overlapping('2023-02-01', '2023-10-01')).to match_array([period_1, period_2, teacher_2_period])
+        expect(DummyMentor.overlapping_with(FakePeriod.new('2023-02-01', '2023-10-01'))).to match_array([period_1, period_2, teacher_2_period])
       end
 
       it "returns periods starting after the specified start date if end date is nil" do
-        expect(DummyMentor.overlapping('2024-01-01', nil)).to match_array([period_3])
+        expect(DummyMentor.overlapping_with(FakePeriod.new('2024-01-01', nil))).to match_array([period_3])
       end
 
       it "does not return periods outside the specified date range" do
-        expect(DummyMentor.overlapping('2022-01-01', '2022-12-31')).to be_empty
+        expect(DummyMentor.overlapping_with(FakePeriod.new('2022-01-01', '2022-12-31'))).to be_empty
       end
     end
   end

--- a/spec/models/induction_period_spec.rb
+++ b/spec/models/induction_period_spec.rb
@@ -70,7 +70,7 @@ describe InductionPeriod do
       end
 
       context "when finished_on is present" do
-        subject { FactoryBot.build(:induction_period, finished_on: Time.zone.today) }
+        subject { FactoryBot.build(:induction_period) }
         it { is_expected.to validate_presence_of(:number_of_terms).with_message("Enter a number of terms") }
       end
     end


### PR DESCRIPTION
This change adds some generated fields to the periods tables that hold a [PostgreSQL range](https://www.postgresql.org/docs/current/rangetypes.html) that spans the `started_on` and `finished_on` boundaries.

These fields are taken care of by PostgreSQL automatically but fully supported by Rails.

Ranges give us much more power than just storing two dates. They allow us to easily:

* check for overlaps for validation purposes
* combine many records to calculate entire durations
* overlap multiple kinds of periods (i.e., to easily work out how much time someone spent with an open `training_period` and `induction_period`)

I've also replaced the existing `.overlapping` method which takes two dates with an `.overlaps_with` scope that takes another period. This approach means we can query the database for clashes without having to return any data and instantiate objects, while remaining readable. 

**This needs to follow #222 which bumps the PostgreSQL version used in CI.**