### PR TITLE
Add production make target, necessary for deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ migration: production-cluster
 sandbox: production-cluster
 	$(eval include config/global_config/sandbox.sh)
 
+production: production-cluster
+	$(if $(or ${SKIP_CONFIRM}, ${CONFIRM_PRODUCTION}), , $(error Missing CONFIRM_PRODUCTION=yes))
+	$(eval include config/global_config/production.sh)
+
 composed-variables:
 	$(eval RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg)
 	$(eval KEYVAULT_NAMES='("${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-app-kv", "${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-inf-kv")')


### PR DESCRIPTION
Omitted in https://github.com/DFE-Digital/ecf2/pull/178
We need the production make target for [`make ci production terraform-apply`](https://github.com/DFE-Digital/ecf2/actions/runs/10790390288/job/29925828557#step:3:78)