### PR TITLE
(Temporarily) Disable production monitoring

### DIFF
--- a/config/terraform/application/config/production.tfvars.json
+++ b/config/terraform/application/config/production.tfvars.json
@@ -3,7 +3,7 @@
     "namespace": "cpd-production",
     "environment": "production",
     "enable_postgres_backup_storage" : true,
-    "enable_monitoring": true,
+    "enable_monitoring": false,
     "external_url": "https://ec2.production.teacherservices.cloud/healthcheck",
     "statuscake_contact_groups": [282453, 291418]
 }


### PR DESCRIPTION
We don't have a production service to monitor yet and [some monitoring resource groups are needed](https://github.com/DFE-Digital/ecf2/actions/runs/10791283568/job/29928783310#step:3:1062) for this to work. 

Disable monitoring temporarily to allow production deploys to work.