### PR TITLE
Remove clause preventing docker builds on dependabot PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
     outputs:
       docker-image-tag: ${{ steps.build-docker-image.outputs.tag }}
     steps:


### PR DESCRIPTION
Simplify deployments: always build the docker image regardless of the github actor or event name.