### PR TITLE
Add write permissions for Dependabot PR docker image pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ on:
       - main
   merge_group:
 
+permissions:
+  packages: write
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Dependabot PRs run with read-only permissions, but the docker image step needs to push to ghcr.io

We might want to revisit this, it could be we don't need to push docker images for dependabot PRs unless we label them with `deploy` but this change should fix the current issues we have.