### PR TITLE
Add user roles

### DIFF
--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -1,0 +1,43 @@
+module Admin
+  class RolesController < AdminController
+    def index
+      @roles_form = RolesForm.new(role_type_params.merge(user:))
+
+      if role_type_params.to_h.any? && @roles_form.valid?
+        redirect_to roles_admin_user_path(id: user.id, role_type: @roles_form.role_type)
+      end
+    end
+
+    def edit
+      @roles_form = RolesForm.new(user:, role_type:)
+    end
+
+    def update
+      @roles_form = RolesForm.new(roles_params.merge(user:, role_type:))
+
+      if @roles_form.valid? && @roles_form.save!
+        redirect_to role_type_admin_user_path(@user)
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def role_type
+      params[:role_type]
+    end
+
+    def role_type_params
+      params.fetch(:admin_roles_form, {}).permit(:role_type)
+    end
+
+    def roles_params
+      params.require(:admin_roles_form).permit(:role_type, role_ids: [])
+    end
+
+    def user
+      @user = User.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,4 +1,12 @@
 class AdminController < ApplicationController
+  include Authorisation
+
   def index
+  end
+
+private
+
+  def authorised?
+    current_user&.dfe_user?
   end
 end

--- a/app/controllers/appropriate_bodies_controller.rb
+++ b/app/controllers/appropriate_bodies_controller.rb
@@ -1,8 +1,15 @@
 class AppropriateBodiesController < ApplicationController
+  include Authorisation
+
   before_action :set_appropriate_body
 
+private
+
   def set_appropriate_body
-    # FIXME: retrieve the current_user's AB
-    @appropriate_body = AppropriateBody.first
+    @appropriate_body = current_user.appropriate_bodies.find(params[:id])
+  end
+
+  def authorised?
+    current_user.appropriate_bodies.any?
   end
 end

--- a/app/controllers/concerns/authorisation.rb
+++ b/app/controllers/concerns/authorisation.rb
@@ -1,0 +1,15 @@
+module Authorisation
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authorise
+  end
+
+  def authorise
+    render "errors/unauthorised", status: :unauthorized unless authorised?
+  end
+
+  def authorised?
+    false
+  end
+end

--- a/app/forms/admin/roles_form.rb
+++ b/app/forms/admin/roles_form.rb
@@ -1,0 +1,33 @@
+module Admin
+  class RolesForm
+    include ActiveModel::Model
+
+    ROLE_TYPES = %w[appropriate_body delivery_partner lead_provider school].freeze
+
+    attr_accessor :role_type, :user, :role_ids
+
+    validates :role_type, inclusion: { in: ROLE_TYPES }
+    validates :user, presence: true
+
+    def collection_for_role_type
+      role_type_class.all
+    end
+
+    def save!
+      roleables = role_ids.compact_blank.map do |role_id|
+        role_type_class.find(role_id)
+      end
+      user.send("#{role_type.pluralize}=", roleables)
+    end
+
+    def role_ids
+      @role_ids ||= user.send(role_type.pluralize).map(&:id)
+    end
+
+  private
+
+    def role_type_class
+      role_type.classify.constantize
+    end
+  end
+end

--- a/app/forms/admin/roles_form.rb
+++ b/app/forms/admin/roles_form.rb
@@ -4,7 +4,8 @@ module Admin
 
     ROLE_TYPES = %w[appropriate_body delivery_partner lead_provider school].freeze
 
-    attr_accessor :role_type, :user, :role_ids
+    attr_accessor :role_type, :user
+    attr_writer :role_ids
 
     validates :role_type, inclusion: { in: ROLE_TYPES }
     validates :user, presence: true

--- a/app/models/appropriate_body_role.rb
+++ b/app/models/appropriate_body_role.rb
@@ -1,4 +1,7 @@
 class AppropriateBodyRole < ApplicationRecord
+  include AliasAssociation
+
   belongs_to :user
   belongs_to :appropriate_body
+  alias_association :roleable, :appropriate_body
 end

--- a/app/models/appropriate_body_role.rb
+++ b/app/models/appropriate_body_role.rb
@@ -1,0 +1,4 @@
+class AppropriateBodyRole < ApplicationRecord
+  belongs_to :user
+  belongs_to :appropriate_body
+end

--- a/app/models/concerns/alias_association.rb
+++ b/app/models/concerns/alias_association.rb
@@ -1,0 +1,11 @@
+module AliasAssociation
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def alias_association(alias_name, association_name)
+      define_method(alias_name) do
+        send(association_name)
+      end
+    end
+  end
+end

--- a/app/models/concerns/authorisable.rb
+++ b/app/models/concerns/authorisable.rb
@@ -15,12 +15,19 @@ module Authorisable
 
   def can_access?(model)
     return true if dfe_user?
-    return AppropriateBodyRole.where(user: self, appropriate_body: model).exists? if model.is_a?(AppropriateBody)
-    return DeliveryPartnerRole.where(user: self, delivery_partner: model).exists? if model.is_a?(DeliveryPartner)
-    return LeadProviderRole.where(user: self, lead_provider: model).exists? if model.is_a?(LeadProvider)
-    return SchoolRole.where(user: self, school: model).exists? if model.is_a?(School)
 
-    false
+    case model
+    when AppropriateBody
+      AppropriateBodyRole.where(user: self, appropriate_body: model).exists?
+    when DeliveryPartner
+      DeliveryPartnerRole.where(user: self, delivery_partner: model).exists?
+    when LeadProvider
+      LeadProviderRole.where(user: self, lead_provider: model).exists?
+    when School
+      SchoolRole.where(user: self, school: model).exists?
+    else
+      false
+    end
   end
 
   def access_type

--- a/app/models/concerns/authorisable.rb
+++ b/app/models/concerns/authorisable.rb
@@ -32,6 +32,10 @@ module Authorisable
     :school if school_roles.any?
   end
 
+  def roles
+    appropriate_body_roles + delivery_partner_roles + lead_provider_roles + school_roles
+  end
+
   def dfe_user?
     dfe_roles.any?
   end

--- a/app/models/concerns/authorisable.rb
+++ b/app/models/concerns/authorisable.rb
@@ -1,0 +1,42 @@
+module Authorisable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :appropriate_body_roles
+    has_many :appropriate_bodies, through: :appropriate_body_roles
+    has_many :delivery_partner_roles
+    has_many :delivery_partners, through: :delivery_partner_roles
+    has_many :lead_provider_roles
+    has_many :lead_providers, through: :lead_provider_roles
+    has_many :school_roles
+    has_many :schools, through: :school_roles
+    has_many :dfe_roles
+  end
+
+  def can_access?(model)
+    return true if dfe_user?
+    return AppropriateBodyRole.where(user: self, appropriate_body: model).exists? if model.is_a?(AppropriateBody)
+    return DeliveryPartnerRole.where(user: self, delivery_partner: model).exists? if model.is_a?(DeliveryPartner)
+    return LeadProviderRole.where(user: self, lead_provider: model).exists? if model.is_a?(LeadProvider)
+    return SchoolRole.where(user: self, school: model).exists? if model.is_a?(School)
+
+    false
+  end
+
+  def access_type
+    return dfe_role_type if dfe_user?
+    return :lead_provider if lead_provider_roles.any?
+    return :delivery_partner if delivery_partner_roles.any?
+    return :appropriate_body if appropriate_body_roles.any?
+
+    :school if school_roles.any?
+  end
+
+  def dfe_user?
+    dfe_roles.any?
+  end
+
+  def dfe_role_type
+    dfe_roles.min_by { |role| DfERole::ROLE_PRECEDENCE.index(role.role_type) }.role_type.to_sym
+  end
+end

--- a/app/models/delivery_partner_role.rb
+++ b/app/models/delivery_partner_role.rb
@@ -1,4 +1,7 @@
 class DeliveryPartnerRole < ApplicationRecord
+  include AliasAssociation
+
   belongs_to :user
   belongs_to :delivery_partner
+  alias_association :roleable, :delivery_partner
 end

--- a/app/models/delivery_partner_role.rb
+++ b/app/models/delivery_partner_role.rb
@@ -1,0 +1,4 @@
+class DeliveryPartnerRole < ApplicationRecord
+  belongs_to :user
+  belongs_to :delivery_partner
+end

--- a/app/models/dfe_role.rb
+++ b/app/models/dfe_role.rb
@@ -1,0 +1,6 @@
+class DfERole < ApplicationRecord
+  # TODO: Is this right?
+  ROLE_PRECEDENCE = %w[super_admin finance admin].freeze
+
+  belongs_to :user
+end

--- a/app/models/lead_provider_role.rb
+++ b/app/models/lead_provider_role.rb
@@ -1,4 +1,7 @@
 class LeadProviderRole < ApplicationRecord
+  include AliasAssociation
+
   belongs_to :user
   belongs_to :lead_provider
+  alias_association :roleable, :lead_provider
 end

--- a/app/models/lead_provider_role.rb
+++ b/app/models/lead_provider_role.rb
@@ -1,0 +1,4 @@
+class LeadProviderRole < ApplicationRecord
+  belongs_to :user
+  belongs_to :lead_provider
+end

--- a/app/models/school_role.rb
+++ b/app/models/school_role.rb
@@ -1,4 +1,7 @@
 class SchoolRole < ApplicationRecord
+  include AliasAssociation
+
   belongs_to :user
   belongs_to :school
+  alias_association :roleable, :school
 end

--- a/app/models/school_role.rb
+++ b/app/models/school_role.rb
@@ -1,0 +1,4 @@
+class SchoolRole < ApplicationRecord
+  belongs_to :user
+  belongs_to :school
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  include Authorisable
+
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true, notify_email: true
 

--- a/app/views/admin/roles/edit.html.erb
+++ b/app/views/admin/roles/edit.html.erb
@@ -1,0 +1,10 @@
+<% page_data(title: "Assign roles") %>
+
+<%= form_for @roles_form, url: roles_admin_user_path(id: @roles_form.user.id, role_type: @roles_form.role_type), method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_check_boxes :role_ids, @roles_form.collection_for_role_type, :id, :name,
+    legend: { text: "Assign #{@roles_form.role_type.humanize.downcase} roles to #{@roles_form.user.name}" } %>
+
+  <%= f.govuk_submit "Save" %>
+<% end %>

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -1,0 +1,21 @@
+<% page_data(title: "Select role type for #{@user.name}") %>
+
+<% if @user.roles.any? %>
+  <h2 class="govuk-heading-m">Current roles for <%= @user.name %></h2>
+
+  <%= govuk_summary_list(
+    rows: @user.roles.map do |role|
+      { key: { text: role.roleable.class.name.underscore.humanize }, value: { text: role.roleable.name } }
+    end
+  ) %>
+<% else %>
+  <p class="govuk-body">No roles assigned</p>
+<% end %>
+
+<%= form_for @roles_form, url: role_type_admin_user_path(@user), method: :get do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_radio_buttons :role_type, Admin::RolesForm::ROLE_TYPES, :to_s, :humanize, legend: { text: "Choose role type" } %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/errors/unauthorised.html.erb
+++ b/app/views/errors/unauthorised.html.erb
@@ -1,0 +1,13 @@
+<%= content_for :page_title, "You are not authorised to access this page" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">You are not authorised to access this page</h1>
+
+    </p>
+    <p class="govuk-body">
+      If you have any questions, please email us at <a class="govuk-link"
+        href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
+    </p>
+  </div>
+</div>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -17,4 +17,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "GIAS"
   inflect.acronym "OTP"
   inflect.acronym "TRN"
+  inflect.acronym "DfE"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+ROLE_TYPE_CONSTRAINT_RE = Regexp.new(Admin::RolesForm::ROLE_TYPES.join('|'))
+
 Rails.application.routes.draw do
   root to: 'pages#home'
   get "healthcheck" => "rails/health#show", as: :rails_health_check
@@ -28,6 +30,16 @@ Rails.application.routes.draw do
   post 'auth/:provider/callback', to: 'sessions#create'
 
   get '/admin', to: 'admin#index'
+
+  namespace :admin do
+    resources :users, only: %i[index] do
+      member do
+        get '/roles', to: 'roles#index', as: :role_type
+        get '/:role_type', to: 'roles#edit', constraints: { role_type: ROLE_TYPE_CONSTRAINT_RE }, as: :roles
+        put '/:role_type', to: 'roles#update', constraints: { role_type: ROLE_TYPE_CONSTRAINT_RE }
+      end
+    end
+  end
 
   resource :appropriate_bodies, only: %i[show], path: 'appropriate-body', as: 'ab' do
     namespace :claim_an_ect, path: 'claim-an-ect' do

--- a/db/migrate/20240912155234_create_appropriate_body_roles.rb
+++ b/db/migrate/20240912155234_create_appropriate_body_roles.rb
@@ -1,0 +1,10 @@
+class CreateAppropriateBodyRoles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :appropriate_body_roles do |t|
+      t.references :user, foreign_key: true
+      t.references :appropriate_body, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240912155318_create_lead_provider_roles.rb
+++ b/db/migrate/20240912155318_create_lead_provider_roles.rb
@@ -1,0 +1,10 @@
+class CreateLeadProviderRoles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :lead_provider_roles do |t|
+      t.references :user, foreign_key: true
+      t.references :lead_provider, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240912155339_create_delivery_partner_roles.rb
+++ b/db/migrate/20240912155339_create_delivery_partner_roles.rb
@@ -1,0 +1,10 @@
+class CreateDeliveryPartnerRoles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :delivery_partner_roles do |t|
+      t.references :user, foreign_key: true
+      t.references :delivery_partner, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240912155402_create_dfe_roles.rb
+++ b/db/migrate/20240912155402_create_dfe_roles.rb
@@ -1,0 +1,12 @@
+class CreateDfeRoles < ActiveRecord::Migration[7.2]
+  def change
+    create_enum :dfe_role_type, %w[admin super_admin finance]
+
+    create_table :dfe_roles do |t|
+      t.enum :role_type, enum_type: :dfe_role_type, default: "admin", null: false
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240912155911_create_school_roles.rb
+++ b/db/migrate/20240912155911_create_school_roles.rb
@@ -1,0 +1,10 @@
+class CreateSchoolRoles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :school_roles do |t|
+      t.references :user, foreign_key: true
+      t.references :school, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_15_123828) do
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "dfe_role_type", ["admin", "super_admin", "finance"]
   create_enum "funding_eligibility_status", ["eligible_for_fip", "eligible_for_cip", "ineligible"]
   create_enum "gias_school_statuses", ["open", "closed", "proposed_to_close", "proposed_to_open"]
   create_enum "induction_eligibility_status", ["eligible", "ineligible"]
@@ -38,6 +39,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_15_123828) do
     t.index ["name"], name: "index_appropriate_bodies_on_name", unique: true
   end
 
+  create_table "appropriate_body_roles", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "appropriate_body_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["appropriate_body_id"], name: "index_appropriate_body_roles_on_appropriate_body_id"
+    t.index ["user_id"], name: "index_appropriate_body_roles_on_user_id"
+  end
+
   create_table "declarations", force: :cascade do |t|
     t.bigint "training_period_id"
     t.string "declaration_type"
@@ -46,11 +56,28 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_15_123828) do
     t.index ["training_period_id"], name: "index_declarations_on_training_period_id"
   end
 
+  create_table "delivery_partner_roles", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "delivery_partner_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["delivery_partner_id"], name: "index_delivery_partner_roles_on_delivery_partner_id"
+    t.index ["user_id"], name: "index_delivery_partner_roles_on_user_id"
+  end
+
   create_table "delivery_partners", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_delivery_partners_on_name", unique: true
+  end
+
+  create_table "dfe_roles", force: :cascade do |t|
+    t.enum "role_type", default: "admin", null: false, enum_type: "dfe_role_type"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_dfe_roles_on_user_id"
   end
 
   create_table "ect_at_school_periods", force: :cascade do |t|
@@ -104,6 +131,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_15_123828) do
     t.index ["appropriate_body_id"], name: "index_induction_periods_on_appropriate_body_id"
     t.index ["ect_at_school_period_id", "started_on"], name: "index_induction_periods_on_ect_at_school_period_id_started_on", unique: true
     t.index ["ect_at_school_period_id"], name: "index_induction_periods_on_ect_at_school_period_id"
+  end
+
+  create_table "lead_provider_roles", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "lead_provider_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lead_provider_id"], name: "index_lead_provider_roles_on_lead_provider_id"
+    t.index ["user_id"], name: "index_lead_provider_roles_on_user_id"
   end
 
   create_table "lead_providers", force: :cascade do |t|
@@ -171,6 +207,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_15_123828) do
     t.index ["academic_year_id"], name: "index_provider_partnerships_on_academic_year_id"
     t.index ["delivery_partner_id"], name: "index_provider_partnerships_on_delivery_partner_id"
     t.index ["lead_provider_id"], name: "index_provider_partnerships_on_lead_provider_id"
+  end
+
+  create_table "school_roles", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "school_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["school_id"], name: "index_school_roles_on_school_id"
+    t.index ["user_id"], name: "index_school_roles_on_user_id"
   end
 
   create_table "schools", force: :cascade do |t|
@@ -339,10 +384,17 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_15_123828) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "appropriate_body_roles", "appropriate_bodies"
+  add_foreign_key "appropriate_body_roles", "users"
+  add_foreign_key "delivery_partner_roles", "delivery_partners"
+  add_foreign_key "delivery_partner_roles", "users"
+  add_foreign_key "dfe_roles", "users"
   add_foreign_key "ect_at_school_periods", "schools"
   add_foreign_key "ect_at_school_periods", "teachers"
   add_foreign_key "induction_periods", "appropriate_bodies"
   add_foreign_key "induction_periods", "ect_at_school_periods"
+  add_foreign_key "lead_provider_roles", "lead_providers"
+  add_foreign_key "lead_provider_roles", "users"
   add_foreign_key "mentor_at_school_periods", "schools"
   add_foreign_key "mentor_at_school_periods", "teachers"
   add_foreign_key "mentorship_periods", "ect_at_school_periods"
@@ -351,6 +403,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_15_123828) do
   add_foreign_key "provider_partnerships", "academic_years", primary_key: "year"
   add_foreign_key "provider_partnerships", "delivery_partners"
   add_foreign_key "provider_partnerships", "lead_providers"
+  add_foreign_key "school_roles", "schools"
+  add_foreign_key "school_roles", "users"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/spec/concerns/authorisable.rb
+++ b/spec/concerns/authorisable.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.shared_examples "Authorisable" do
+  let(:user) { subject }
+
+  describe "#can_access?" do
+    %i[appropriate_body delivery_partner lead_provider school].each do |organisation_type|
+      context "for an #{organisation_type}" do
+        let(:organisation) { FactoryBot.create(organisation_type) }
+
+        it "returns true when the user has the appropriate role" do
+          FactoryBot.create(:"#{organisation_type}_role", user:, organisation_type => organisation)
+
+          expect(user.can_access?(organisation)).to be true
+        end
+
+        it "returns false when the user does not have the appropriate role" do
+          expect(user.can_access?(organisation)).to be false
+        end
+      end
+    end
+
+    it "returns true when authorised via DfE role" do
+      FactoryBot.create(:dfe_role, user:)
+      ab = FactoryBot.create(:appropriate_body)
+
+      expect(user.can_access?(ab)).to be true
+    end
+
+    it "returns false when asked about an inaccessible model" do
+      expect(user.can_access?(FactoryBot.build(:teacher))).to be false
+    end
+  end
+
+  describe "#access_type" do
+    context "when user has DfE role" do
+      it "returns the DfE role type" do
+        role_type = DfERole::ROLE_PRECEDENCE.sample
+        FactoryBot.create(:dfe_role, user:, role_type:)
+        expect(user.access_type).to eq(role_type.to_sym)
+      end
+    end
+
+    context "when the user has multiple DfE roles" do
+      it "returns the highest precedence role type" do
+        FactoryBot.create(:dfe_role, user:, role_type: "admin")
+        FactoryBot.create(:dfe_role, user:, role_type: "super_admin")
+        expect(user.access_type).to eq(:super_admin)
+      end
+    end
+
+    context "when user has appropriate body role" do
+      it "returns :appropriate_body" do
+        FactoryBot.create(:appropriate_body_role, user:)
+        expect(user.access_type).to eq(:appropriate_body)
+      end
+    end
+
+    context "when user has lead provider role" do
+      it "returns :lead_provider" do
+        FactoryBot.create(:lead_provider_role, user:)
+        expect(user.access_type).to eq(:lead_provider)
+      end
+    end
+
+    context "when user has delivery partner role" do
+      it "returns :delivery_partner" do
+        FactoryBot.create(:delivery_partner_role, user:)
+        expect(user.access_type).to eq(:delivery_partner)
+      end
+    end
+
+    context "when user has school role" do
+      it "returns :school" do
+        FactoryBot.create(:school_role, user:)
+        expect(user.access_type).to eq(:school)
+      end
+    end
+
+    context "when user has no roles" do
+      it "returns nil" do
+        expect(user.access_type).to be_nil
+      end
+    end
+  end
+end

--- a/spec/factories/appropriate_body_factory.rb
+++ b/spec/factories/appropriate_body_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory(:appropriate_body) do
-    name { "#{Faker::Lorem.word.capitalize} AB" }
+    name { "#{Faker::Lorem.unique.word.capitalize} AB" }
     sequence(:local_authority_code, 100)
     sequence(:establishment_number, 1000)
   end

--- a/spec/factories/appropriate_body_role_factory.rb
+++ b/spec/factories/appropriate_body_role_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory(:appropriate_body_role) do
+    user { nil }
+    appropriate_body { nil }
+  end
+end

--- a/spec/factories/delivery_partner_role_factory.rb
+++ b/spec/factories/delivery_partner_role_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory(:delivery_partner_role) do
+    user { nil }
+    delivery_partner { nil }
+  end
+end

--- a/spec/factories/dfe_role_factory.rb
+++ b/spec/factories/dfe_role_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory(:dfe_role) do
+    user { nil }
+    role_type { "admin" }
+  end
+end

--- a/spec/factories/lead_provider_role_factory.rb
+++ b/spec/factories/lead_provider_role_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory(:lead_provider_role) do
+    user { nil }
+    lead_provider { nil }
+  end
+end

--- a/spec/factories/school_role_factory.rb
+++ b/spec/factories/school_role_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory(:school_role) do
+    user { nil }
+    school { nil }
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -2,5 +2,11 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "john.doe#{n}@example.com" }
     sequence(:name) { |n| "John Doe #{n}" }
+
+    trait :admin do
+      after(:create) do |user|
+        FactoryBot.create(:dfe_role, user:)
+      end
+    end
   end
 end

--- a/spec/features/admin/assign_user_roles_spec.rb
+++ b/spec/features/admin/assign_user_roles_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe "Admin assigns user roles" do
+  include UserHelper
+
+  scenario "when the user has no roles" do
+    given_i_am_logged_in_as_an_admin
+    and_there_are_roles_which_can_be_assigned
+    and_there_is_a_user_with_no_roles
+    when_i_visit_the_user_roles_page
+    and_i_choose_the_appropriate_body_role_type
+    and_i_assign_roles_to_the_user
+    then_the_user_has_the_appropriate_roles
+  end
+
+  scenario "when the user has existing roles" do
+    given_i_am_logged_in_as_an_admin
+    and_there_are_roles_which_can_be_assigned
+    and_there_is_a_user_with_roles
+    when_i_visit_the_user_roles_page
+    and_i_choose_the_appropriate_body_role_type
+    and_i_uncheck_existing_roles
+    and_i_assign_roles_to_the_user
+    then_the_user_has_the_appropriate_roles
+    and_i_choose_the_appropriate_body_role_type
+    then_i_can_see_the_correct_roles_are_checked
+  end
+
+  def given_i_am_logged_in_as_an_admin
+    sign_in_as_admin
+  end
+
+  def and_there_are_roles_which_can_be_assigned
+    @appropriate_bodies = FactoryBot.create_list(:appropriate_body, 3)
+  end
+
+  def and_there_is_a_user
+    @user = FactoryBot.create(:user)
+  end
+  alias_method :and_there_is_a_user_with_no_roles, :and_there_is_a_user
+
+  def and_there_is_a_user_with_roles
+    and_there_is_a_user
+    @user.appropriate_bodies << @appropriate_bodies.second
+  end
+
+  def when_i_visit_the_user_roles_page
+    page.goto role_type_admin_user_path(@user)
+  end
+
+  def and_i_choose_the_appropriate_body_role_type
+    page.get_by_label("Appropriate body").check
+    page.get_by_role("button", name: "Continue").click
+  end
+
+  def and_i_uncheck_existing_roles
+    expect(page.get_by_text("Assign appropriate body roles to #{@user.name}")).to be_visible
+    page.get_by_label(@appropriate_bodies.second.name).uncheck
+  end
+
+  def and_i_assign_roles_to_the_user
+    expect(page.get_by_text("Assign appropriate body roles to #{@user.name}")).to be_visible
+    page.get_by_label(@appropriate_bodies.first.name).check
+    page.get_by_label(@appropriate_bodies.last.name).check
+    page.get_by_role("button", name: "Save").click
+  end
+
+  def then_the_user_has_the_appropriate_roles
+    expect(page.get_by_text("Current roles for #{@user.name}")).to be_visible
+    expect(page.get_by_text(@appropriate_bodies.first.name)).to be_visible
+    expect(page.get_by_text(@appropriate_bodies.last.name)).to be_visible
+  end
+
+  def then_i_can_see_the_correct_roles_are_checked
+    expect(page.get_by_label(@appropriate_bodies.first.name)).to be_checked
+    expect(page.get_by_label(@appropriate_bodies.second.name)).not_to be_checked
+    expect(page.get_by_label(@appropriate_bodies.last.name)).to be_checked
+  end
+end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin" do
-  include AuthenticationHelper
-
+  include UserHelper
   # TODO: This test should be replaced with something meaningful.
   # Just here to prove Playwright is working.
   scenario "visiting the admin placeholder page" do

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Admin" do
+  include AuthenticationHelper
+
   # TODO: This test should be replaced with something meaningful.
   # Just here to prove Playwright is working.
   scenario "visiting the admin placeholder page" do

--- a/spec/forms/admin/roles_form_spec.rb
+++ b/spec/forms/admin/roles_form_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Admin::RolesForm, type: :model do
+  let(:user) { FactoryBot.create(:user) }
+  let(:appropriate_bodies) { FactoryBot.build_list(:appropriate_body, 3) }
+  let(:role_ids) { appropriate_bodies.map(&:id) }
+  let(:roles_form) { described_class.new(role_type: "appropriate_body", user:, role_ids:) }
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      expect(roles_form).to be_valid
+    end
+
+    it "is invalid with an invalid role_type" do
+      roles_form.role_type = "invalid_role"
+      expect(roles_form).not_to be_valid
+      expect(roles_form.errors[:role_type]).to include("is not included in the list")
+    end
+  end
+
+  describe "#collection_for_role_type" do
+    it "returns all records for the role type" do
+      expect(roles_form.collection_for_role_type).to eq(AppropriateBody.all)
+    end
+  end
+
+  describe "#save!" do
+    let!(:appropriate_bodies) { FactoryBot.create_list(:appropriate_body, 3) }
+    let(:role_ids) { [appropriate_bodies.second.id, appropriate_bodies.last.id] }
+
+    it "sets the roles for the user" do
+      user.appropriate_body_roles << FactoryBot.create(:appropriate_body_role, user:, appropriate_body: appropriate_bodies.first)
+
+      expect { roles_form.save! }.to change { user.appropriate_bodies.count }.by(1)
+      expect(user.appropriate_bodies).to match_array(appropriate_bodies.last(2))
+    end
+  end
+end

--- a/spec/models/appropriate_body_role_spec.rb
+++ b/spec/models/appropriate_body_role_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe AppropriateBodyRole, type: :model do
+  it { should belong_to(:user) }
+  it { should belong_to(:appropriate_body) }
+end

--- a/spec/models/delivery_partner_role_spec.rb
+++ b/spec/models/delivery_partner_role_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe DeliveryPartnerRole, type: :model do
+  it { should belong_to(:user) }
+  it { should belong_to(:delivery_partner) }
+end

--- a/spec/models/dfe_role_spec.rb
+++ b/spec/models/dfe_role_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe DfERole, type: :model do
+  it { should belong_to(:user) }
+  it { is_expected.to allow_value("admin", "super_admin", "finance").for(:role_type) }
+
+  it "defines role precendence" do
+    expect(described_class::ROLE_PRECEDENCE).to eq(%w[super_admin finance admin])
+  end
+end

--- a/spec/models/lead_provider_role_spec.rb
+++ b/spec/models/lead_provider_role_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe LeadProviderRole, type: :model do
+  it { should belong_to(:user) }
+  it { should belong_to(:lead_provider) }
+end

--- a/spec/models/school_role_spec.rb
+++ b/spec/models/school_role_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe SchoolRole, type: :model do
+  it { should belong_to(:user) }
+  it { should belong_to(:school) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require Rails.root.join "spec/concerns/authorisable"
 
 describe User do
   subject(:user) { FactoryBot.build(:user) }
@@ -6,4 +7,6 @@ describe User do
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_uniqueness_of(:email) }
   it { is_expected.to validate_presence_of(:name) }
+
+  it_behaves_like "Authorisable"
 end

--- a/spec/requests/admin_spec.rb
+++ b/spec/requests/admin_spec.rb
@@ -6,5 +6,30 @@ RSpec.describe "Admin", type: :request do
       get "/admin"
       expect(response).to redirect_to(sign_in_path)
     end
+
+    context "with an authenticated user" do
+      let(:session_manager) do
+        instance_double(Sessions::SessionManager, provider: "developer", expires_at: 2.hours.from_now)
+      end
+      let(:user) { FactoryBot.build(:user) }
+
+      before do
+        allow(Sessions::SessionManager).to receive(:new).and_return(session_manager)
+        allow(session_manager).to receive(:load_from_session).and_return(user)
+      end
+
+      it "requires authorisation" do
+        get "/admin"
+
+        expect(response.status).to eq(401)
+      end
+
+      it "allows access to DfE users" do
+        FactoryBot.create(:dfe_role, user:)
+
+        get "/admin"
+        expect(response.status).to eq(200)
+      end
+    end
   end
 end

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -10,7 +10,7 @@ module UserHelper
   end
 
   def sign_in_as_admin
-    FactoryBot.create(:user, email: "admin@example.com", name: "Admin User").tap do |user|
+    FactoryBot.create(:user, :admin, email: "admin@example.com", name: "Admin User").tap do |user|
       sign_in_as(user)
     end
   end


### PR DESCRIPTION
Part of #241 

#### Adds association models for users and roles. 

We treat the association between eg. a School and a User as the required authorisation for that user to perform common school administrator tasks for the associated school.

There are 5 different user roles: 
- DfE user: either super admin, finance or admin user, the default is admin. These have the most advanced access, typically via the admin interface.
- Lead provider user: These users have an association to a lead provider, they may see additional configuration options for that provider. How their view of the service differs from other users is TBC.
- Delivery partner user: Similar to lead provider users, there will be additional configuration available.
- Appropriate body user: These users have an association with an appropriate body, they will see a different view of the service from school users.
- School user: These school administrators will manage ECTs and Mentors for their school using the appropriate service interface.

#### Authorisation mechanism

I've added a concern to `User` model with helpers to determine general user access and access to specific resources.
This is a best guess as we don't have all the relevant user journeys built yet.

Also there is a controller concern to check user access, for now this is only implemented for users with one or more `DfERole`  via `AdminController`

#### Admin UI for user role management

This doesn't currently handle assigning DfE user roles which are different from model association roles. We should probably restrict that to super admins and handle elsewhere.

GET `/admin/users/:id/roles`
![image](https://github.com/user-attachments/assets/5f9073bb-ce13-4030-bb6a-83bc8e5f8a5e)

Assigning roles by type:
![image](https://github.com/user-attachments/assets/f3d1f6d9-c489-4dad-b57b-cc3dd203fe2d)

**Metaprogramming Warning**

All the association role classes are the same shape and do the same thing, and we agreed to avoid polymorphic associations. The admin roles form and relevant views contain a bit of metaprogramming to DRY up persisting, inflating and rendering roles for a user. It may be preferable to be explicit.