### PR TITLE
Add Capybara for non-js features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,10 @@ group :development, :test do
   gem "shoulda-matchers"
 end
 
+group :test do
+  gem "capybara"
+end
+
 group :nanoc do
   gem "asciidoctor"
   gem "nanoc"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,15 @@ GEM
     brakeman (6.2.1)
       racc
     builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     coderay (1.1.3)
     colored (1.2)
     concurrent-ruby (1.3.4)
@@ -208,6 +217,7 @@ GEM
       notifications-ruby-client (~> 6.0)
       rack (>= 2.1.4.1)
     marcel (1.0.4)
+    matrix (0.4.2)
     memo_wise (1.9.0)
     method_source (1.1.0)
     mime-types (3.5.2)
@@ -497,6 +507,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.6.18)
 
 PLATFORMS
@@ -520,6 +532,7 @@ DEPENDENCIES
   base32
   bootsnap
   brakeman
+  capybara
   cssbundling-rails
   debug
   factory_bot_rails

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Admin", type: :feature do
+  # TODO: This test should be replaced with something meaningful.
+  # Just here to prove Capybara is working.
+  scenario "visiting the admin placeholder page" do
+    given_i_am_logged_in_as_an_admin
+    when_i_visit_the_admin_placeholder_page
+    then_i_should_see_the_admin_placeholder_page
+  end
+
+  def given_i_am_logged_in_as_an_admin
+    session_manager = instance_double(Sessions::SessionManager, provider: "developer", expires_at: 2.hours.from_now)
+    admin = FactoryBot.create(:user)
+    allow(Sessions::SessionManager).to receive(:new).and_return(session_manager)
+    allow(session_manager).to receive(:load_from_session).and_return(admin)
+  end
+
+  def when_i_visit_the_admin_placeholder_page
+    visit admin_path
+  end
+
+  def then_i_should_see_the_admin_placeholder_page
+    expect(page).to have_content("Placeholder page for the admin site")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,9 @@ require_relative '../config/environment'
 
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'capybara/rspec'
+
+Capybara.server = :puma, { Silent: true }
 
 Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 


### PR DESCRIPTION
Following a discussion about Playwright we've decided to add Capybara as a quick way to get non-JS feature specs up and running. We may be able to use the [Capybara Playwright driver](https://github.com/YusukeIwaki/capybara-playwright-driver) in future. 