### PR TITLE
use capybara to manage the rails app on feature testing

### DIFF
--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -1,6 +1,4 @@
 class CitiesController < ApplicationController
-  skip_before_action :authenticate
-
   def index
   end
 

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -1,6 +1,4 @@
 class CountriesController < ApplicationController
-  skip_before_action :authenticate
-
   def index
   end
 

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe "Admin", type: :feature do
+RSpec.describe "Admin" do
   # TODO: This test should be replaced with something meaningful.
-  # Just here to prove Capybara is working.
+  # Just here to prove Playwright is working.
   scenario "visiting the admin placeholder page" do
     given_i_am_logged_in_as_an_admin
     when_i_visit_the_admin_placeholder_page
@@ -10,17 +10,15 @@ RSpec.describe "Admin", type: :feature do
   end
 
   def given_i_am_logged_in_as_an_admin
-    session_manager = instance_double(Sessions::SessionManager, provider: "developer", expires_at: 2.hours.from_now)
-    admin = FactoryBot.create(:user)
-    allow(Sessions::SessionManager).to receive(:new).and_return(session_manager)
-    allow(session_manager).to receive(:load_from_session).and_return(admin)
+    @user = FactoryBot.create(:user, email: "user@example.com", name: "Testing User")
+    sign_in_as(@user)
   end
 
   def when_i_visit_the_admin_placeholder_page
-    visit admin_path
+    page.goto(admin_path)
   end
 
   def then_i_should_see_the_admin_placeholder_page
-    expect(page).to have_content("Placeholder page for the admin site")
+    expect(page.get_by_text("Placeholder page for the admin site")).to be_visible
   end
 end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe "Admin" do
   end
 
   def given_i_am_logged_in_as_an_admin
-    @user = FactoryBot.create(:user, email: "user@example.com", name: "Testing User")
-    sign_in_as(@user)
+    sign_in_as_admin
   end
 
   def when_i_visit_the_admin_placeholder_page

--- a/spec/features/js_1_spec.rb
+++ b/spec/features/js_1_spec.rb
@@ -1,77 +1,77 @@
-describe 'autocomplete 1 JS', :js do
-  let(:page) { RSpec.configuration.playwright_page }
+describe "autocomplete" do
+  let(:user) { FactoryBot.create(:user, email: "user@example.com", name: "Testing User") }
 
-  it 'can use Playwright with JavaScript enabled to test a feature' do
-    page.goto("/countries")
-
-    # Expect list of options to be hidden
-    expect(page.locator('#my-autocomplete__listbox')).not_to be_visible
-
-    # Type first chars into the autocomplete field
-    autocomplete = page.wait_for_selector('input#my-autocomplete')
-    autocomplete.type('un')
-
-    # Expect list of options to be visible
-    expect(page.locator('#my-autocomplete__listbox')).to be_visible
-
-    7.times { page.keyboard.press('ArrowDown') }
-    page.keyboard.press('Enter')
-
-    expect(autocomplete.input_value).to eq("United Kingdom")
-
-    page.get_by_role("button", name: 'Go to country').click
-    expect(page.get_by_text("Welcome to United Kingdom")).to be_visible
-    expect(page.url).to eq("#{RSpecPlaywright::RAILS_SERVER_URL}/countries/united-kingdom")
+  before do
+    sign_in_as(user)
   end
-end
 
-describe 'autocomplete 2' do
-  let(:page) { RSpec.configuration.playwright_page }
+  describe 'autocomplete 1 JS', :js do
+    it 'can use Playwright with JavaScript enabled to test a feature' do
+      page.goto("/countries")
 
-  it 'can use Playwright with JavaScript disabled to test a feature' do
-    page.goto("/countries")
+      # Expect list of options to be hidden
+      expect(page.locator('#my-autocomplete__listbox')).not_to be_visible
 
-    expect(page.get_by_text("Select your country")).to be_visible
-    expect(page.get_by_role("button", name: 'Go to country')).to be_visible
+      # Type first chars into the autocomplete field
+      autocomplete = page.wait_for_selector('input#my-autocomplete')
+      autocomplete.type('un')
+
+      # Expect list of options to be visible
+      expect(page.locator('#my-autocomplete__listbox')).to be_visible
+
+      7.times { page.keyboard.press('ArrowDown') }
+      page.keyboard.press('Enter')
+
+      expect(autocomplete.input_value).to eq("United Kingdom")
+
+      page.get_by_role("button", name: 'Go to country').click
+      expect(page.get_by_text("Welcome to United Kingdom")).to be_visible
+      expect(page.url).to eq("#{Capybara.current_session.server.base_url}/countries/united-kingdom")
+    end
   end
-end
 
-describe 'autocomplete 3 JS', :js do
-  let(:page) { RSpec.configuration.playwright_page }
+  describe 'autocomplete 2' do
+    it 'can use Playwright with JavaScript disabled to test a feature' do
+      page.goto("/countries")
 
-  it 'can switch back to Playwright with JavaScript enabled to test another feature' do
-    page.goto("/countries")
-
-    # Expect list of options to be hidden
-    expect(page.locator('#my-autocomplete__listbox')).not_to be_visible
-
-    # Type first chars into the autocomplete field
-    autocomplete = page.wait_for_selector('input#my-autocomplete')
-    autocomplete.type('un')
-
-    # Expect list of options to be visible
-    expect(page.locator('#my-autocomplete__listbox')).to be_visible
-
-    7.times { page.keyboard.press('ArrowDown') }
-    page.keyboard.press('Enter')
-
-    expect(autocomplete.input_value).to eq("United Kingdom")
-
-    page.get_by_role("button", name: 'Go to country').click
-    expect(page.get_by_text("Welcome to United Kingdom")).to be_visible
-    expect(page.url).to eq("#{RSpecPlaywright::RAILS_SERVER_URL}/countries/united-kingdom")
+      expect(page.get_by_text("Select your country")).to be_visible
+      expect(page.get_by_role("button", name: 'Go to country')).to be_visible
+    end
   end
-end
 
-describe 'city form' do
-  let(:page) { RSpec.configuration.playwright_page }
+  describe 'autocomplete 3 JS', :js do
+    it 'can switch back to Playwright with JavaScript enabled to test another feature' do
+      page.goto("/countries")
 
-  it 'can switch back to Playwright with JavaScript disabled to test another feature' do
-    page.goto("/cities")
-    page.get_by_label('Name').fill('London')
-    page.get_by_role("button", name: "Go to city").click
+      # Expect list of options to be hidden
+      expect(page.locator('#my-autocomplete__listbox')).not_to be_visible
 
-    expect(page.get_by_text("Welcome to London")).to be_visible
-    expect(page.url).to eq("#{RSpecPlaywright::RAILS_SERVER_URL}/cities/london")
+      # Type first chars into the autocomplete field
+      autocomplete = page.wait_for_selector('input#my-autocomplete')
+      autocomplete.type('un')
+
+      # Expect list of options to be visible
+      expect(page.locator('#my-autocomplete__listbox')).to be_visible
+
+      7.times { page.keyboard.press('ArrowDown') }
+      page.keyboard.press('Enter')
+
+      expect(autocomplete.input_value).to eq("United Kingdom")
+
+      page.get_by_role("button", name: 'Go to country').click
+      expect(page.get_by_text("Welcome to United Kingdom")).to be_visible
+      expect(page.url).to eq("#{Capybara.current_session.server.base_url}/countries/united-kingdom")
+    end
+  end
+
+  describe 'city form' do
+    it 'can switch back to Playwright with JavaScript disabled to test another feature' do
+      page.goto("/cities")
+      page.get_by_label('Name').fill('London')
+      page.get_by_role("button", name: "Go to city").click
+
+      expect(page.get_by_text("Welcome to London")).to be_visible
+      expect(page.url).to eq("#{Capybara.current_session.server.base_url}/cities/london")
+    end
   end
 end

--- a/spec/features/js_3_spec.rb
+++ b/spec/features/js_3_spec.rb
@@ -1,5 +1,9 @@
 describe 'city form' do
-  let(:page) { RSpec.configuration.playwright_page }
+  let(:user) { FactoryBot.create(:user, email: "user@example.com", name: "Testing User") }
+
+  before do
+    sign_in_as(user)
+  end
 
   5.times do
     it 'can test a page containing no JavaScript with a JS-disabled Playwright browser' do
@@ -8,7 +12,7 @@ describe 'city form' do
       page.get_by_role("button", name: "Go to city").click
 
       expect(page.get_by_text("Welcome to London")).to be_visible
-      expect(page.url).to eq("#{RSpecPlaywright::RAILS_SERVER_URL}/cities/london")
+      expect(page.url).to eq("#{Capybara.current_session.server.base_url}/cities/london")
     end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,15 @@
+require 'capybara/rspec'
+
+class CapybaraNullDriver < Capybara::Driver::Base
+  def needs_server?
+    true
+  end
+end
+
+Capybara.server = :puma, { Silent: true }
+Capybara.register_driver(:js_enabled) { CapybaraNullDriver.new }
+Capybara.register_driver(:js_disabled) { CapybaraNullDriver.new }
+Capybara.default_max_wait_time = 5
+Capybara.default_driver = :js_disabled
+Capybara.javascript_driver = :js_enabled
+Capybara.save_path = 'tmp/capybara'

--- a/spec/support/features/page_helper.rb
+++ b/spec/support/features/page_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageHelper
+  def page
+    RSpec.configuration.playwright_page
+  end
+end
+
+RSpec.configure do |config|
+  config.include PageHelper, type: :feature
+end

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module UserHelper
+  def sign_in_as(user)
+    page.goto(otp_sign_in_path)
+    page.get_by_label('Email address').type(user.email)
+    page.get_by_role("button", name: 'Request code to sign in').click
+    page.get_by_label('Sign in code').type(ROTP::TOTP.new(user.reload.otp_secret, issuer: "ECF2").now)
+    page.get_by_role("button", name: 'Sign in').click
+  end
+
+  def sign_out
+    page.goto(otp_sign_out_path)
+  end
+end
+
+RSpec.configure do |config|
+  config.include UserHelper, type: :feature
+end

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -9,6 +9,12 @@ module UserHelper
     page.get_by_role("button", name: 'Sign in').click
   end
 
+  def sign_in_as_admin
+    FactoryBot.create(:user, email: "admin@example.com", name: "Admin User").tap do |user|
+      sign_in_as(user)
+    end
+  end
+
   def sign_out
     page.goto(otp_sign_out_path)
   end

--- a/spec/support/rspec_playwright.rb
+++ b/spec/support/rspec_playwright.rb
@@ -1,17 +1,8 @@
-require 'net/http'
-require 'uri'
-require 'timeout'
+require 'capybara'
 require 'playwright'
 
 module RSpecPlaywright
   PLAYWRIGHT_CLI_EXECUTABLE_PATH = "./node_modules/.bin/playwright".freeze
-  RAILS_SERVER_PROTOCOL = "http".freeze
-  RAILS_SERVER_HOST = "localhost".freeze
-  RAILS_SERVER_PORT = rand(50_000..65_000)
-  RAILS_SERVER_URL = "#{RAILS_SERVER_PROTOCOL}://#{RAILS_SERVER_HOST}:#{RAILS_SERVER_PORT}".freeze
-  RAILS_SERVER_BOOT_COMMAND = "exec bin/rails server -e test -p #{RAILS_SERVER_PORT} > tmp/rails_playwright_last_run 2>&1".freeze
-  RAILS_SERVER_BOOT_TIMEOUT_SECONDS = 10
-  RAILS_SERVER_BOOT_TIMEOUT_MESSAGE = "Rails server boot timed out!".freeze
 
   # rubocop:disable Rails/SaveBang
   def self.start_browser(javascript_enabled: false)
@@ -19,7 +10,7 @@ module RSpecPlaywright
                         .playwright
                         .chromium
                         .launch(headless: true)
-    browser.new_page(baseURL: RAILS_SERVER_URL, javaScriptEnabled: javascript_enabled)
+    browser.new_page(baseURL: Capybara.current_session.server.base_url, javaScriptEnabled: javascript_enabled)
   end
   # rubocop:enable Rails/SaveBang
 
@@ -28,27 +19,5 @@ module RSpecPlaywright
     RSpec.configuration.playwright_page_with_js_disabled&.context&.browser&.close
     RSpec.configuration.playwright_page_with_js_enabled = nil
     RSpec.configuration.playwright_page_with_js_disabled = nil
-  end
-
-  def self.start_rails_app
-    spawn(RAILS_SERVER_BOOT_COMMAND).tap do |pid|
-      Timeout.timeout(RAILS_SERVER_BOOT_TIMEOUT_SECONDS) do
-        loop do
-          Net::HTTP.get_response(URI.parse(RAILS_SERVER_URL))
-          break
-        rescue Errno::ECONNREFUSED
-          sleep 1
-        end
-      end
-    rescue Timeout::Error
-      stop_rails_server(pid:)
-      raise RAILS_SERVER_BOOT_TIMEOUT_MESSAGE
-    end
-  end
-
-  def self.stop_rails_app(pid: RSpec.configuration.rails_server_pid)
-    Process.kill("TERM", pid) if pid
-    Process.wait(pid) if pid
-    RSpec.configuration.rails_server_pid = nil
   end
 end

--- a/spec/support/testing_with_playwright.rb
+++ b/spec/support/testing_with_playwright.rb
@@ -4,24 +4,20 @@ RSpec.configure do |config|
   config.add_setting :playwright_page
   config.add_setting :playwright_page_with_js_enabled
   config.add_setting :playwright_page_with_js_disabled
-  config.add_setting :rails_server_pid
 
-  # Start/Reuse JS-disabled Playwright browser and Rails app
+  # Start/Reuse Playwright browser
   config.before(type: :feature) do
-    config.rails_server_pid ||= RSpecPlaywright.start_rails_app
-    config.playwright_page_with_js_disabled ||= RSpecPlaywright.start_browser(javascript_enabled: false)
-    config.playwright_page = config.playwright_page_with_js_disabled
+    if Capybara.current_driver == :js_enabled
+      config.playwright_page_with_js_enabled ||= RSpecPlaywright.start_browser(javascript_enabled: true)
+      config.playwright_page = config.playwright_page_with_js_enabled
+    else
+      config.playwright_page_with_js_disabled ||= RSpecPlaywright.start_browser(javascript_enabled: false)
+      config.playwright_page = config.playwright_page_with_js_disabled
+    end
   end
 
-  # Start/Reuse JS-enabled Playwright browser
-  config.before(type: :feature, js: true) do
-    config.playwright_page_with_js_enabled ||= RSpecPlaywright.start_browser(javascript_enabled: true)
-    config.playwright_page = config.playwright_page_with_js_enabled
-  end
-
-  # Close Playwright browsers and stop Rails app
+  # Close Playwright browsers
   config.after(:suite) do
     RSpecPlaywright.close_browsers
-    RSpecPlaywright.stop_rails_app
   end
 end


### PR DESCRIPTION
This implements the old [option 2](https://github.com/DFE-Digital/ecf2/pull/181) and uses Capybara to manage the Rails app with Playwright for the features. It gives us the benefits of [Playwright's nice API](https://playwright-ruby-client.vercel.app/docs/api/page), its speed, and its visual debugging along with the ability to set data up on a feature by feature basis, something we couldn't do with [option 3](https://github.com/DFE-Digital/ecf2/pull/183).