### PR TITLE
Remove Capybara for now while we adjust Playwright

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,10 +41,6 @@ group :development, :test do
   gem "shoulda-matchers"
 end
 
-group :test do
-  gem "capybara"
-end
-
 group :nanoc do
   gem "asciidoctor"
   gem "nanoc"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,15 +95,6 @@ GEM
     brakeman (6.2.1)
       racc
     builder (3.3.0)
-    capybara (3.40.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.11)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
     coderay (1.1.3)
     colored (1.2)
     concurrent-ruby (1.3.4)
@@ -217,7 +208,6 @@ GEM
       notifications-ruby-client (~> 6.0)
       rack (>= 2.1.4.1)
     marcel (1.0.4)
-    matrix (0.4.2)
     memo_wise (1.9.0)
     method_source (1.1.0)
     mime-types (3.5.2)
@@ -507,8 +497,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
     zeitwerk (2.6.18)
 
 PLATFORMS
@@ -532,7 +520,6 @@ DEPENDENCIES
   base32
   bootsnap
   brakeman
-  capybara
   cssbundling-rails
   debug
   factory_bot_rails

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Admin", type: :feature do
+RSpec.xdescribe "Admin", type: :feature do
   # TODO: This test should be replaced with something meaningful.
   # Just here to prove Capybara is working.
   scenario "visiting the admin placeholder page" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,9 +4,6 @@ require_relative '../config/environment'
 
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
-require 'capybara/rspec'
-
-Capybara.server = :puma, { Silent: true }
 
 Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 


### PR DESCRIPTION
We just had a discussion and decided to have another try at using only Playwright. This change removes Capybara and marks the test that relies on it as pending while we get Playwright behaving better in #299

Refs #292
