### PR TITLE
Appropriate body claims additional specs

### DIFF
--- a/app/controllers/appropriate_bodies_controller.rb
+++ b/app/controllers/appropriate_bodies_controller.rb
@@ -6,7 +6,11 @@ class AppropriateBodiesController < ApplicationController
 private
 
   def set_appropriate_body
-    @appropriate_body = current_user.appropriate_bodies.find(params[:id])
+    # FIXME: this should be stored in the session when someone logs
+    #        in, then we can easily switch between ABs if a user is
+    #        linked ot more than one
+
+    @appropriate_body = current_user.appropriate_bodies.first
   end
 
   def authorised?

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -8,5 +8,15 @@ FactoryBot.define do
         FactoryBot.create(:dfe_role, user:)
       end
     end
+
+    trait :appropriate_body_user do
+      after(:create) do |user|
+        FactoryBot.create(
+          :appropriate_body_role,
+          user:,
+          appropriate_body: FactoryBot.create(:appropriate_body)
+        )
+      end
+    end
   end
 end

--- a/spec/features/appropriate_bodies/claim_an_ect_spec.rb
+++ b/spec/features/appropriate_bodies/claim_an_ect_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe 'Claiming an ECT' do
+  include_context 'fake_trs_api_client'
+
+  let(:page) { RSpec.configuration.playwright_page }
+
+  before { sign_in_as_appropriate_body_user }
+
+  scenario 'Happy path' do
+    given_i_am_on_the_claim_an_ect_find_page
+    if_i_submit_with_errors_the_errors_are_reported_to_me(expected_errors: 2)
+    when_i_enter_a_trn_and_date_of_birth_that_exist_in_trs
+    and_i_submit_the_form
+
+    now_i_should_be_on_the_claim_an_ect_check_page
+    if_i_submit_with_errors_the_errors_are_reported_to_me(expected_errors: 1)
+    when_i_confirm_the_details_are_correct
+    and_i_submit_the_form
+
+    now_i_should_be_on_the_claim_an_ect_register_page
+    if_i_submit_with_errors_the_errors_are_reported_to_me(expected_errors: 2)
+    when_i_enter_the_start_date
+    and_choose_an_induction_programme
+    and_i_submit_the_form
+
+    then_i_should_be_on_the_confirmation_page
+    and_the_data_i_submitted_should_be_saved_on_the_pending_record
+  end
+
+private
+
+  def given_i_am_on_the_claim_an_ect_find_page
+    path = '/appropriate-body/claim-an-ect/find-ect/new'
+    page.goto(path)
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_enter_a_trn_and_date_of_birth_that_exist_in_trs
+    page.get_by_label('Teacher reference number').fill('1234567')
+    page.get_by_label('Day').fill('1')
+    page.get_by_label('Month').fill('2')
+    page.get_by_label('Year').fill('2003')
+  end
+
+  def when_i_submit_the_form
+    page.get_by_role('button', name: "Continue").click
+  end
+  alias_method :and_i_submit_the_form, :when_i_submit_the_form
+
+  def now_i_should_be_on_the_claim_an_ect_check_page
+    @pending_induction_submission = PendingInductionSubmission.last
+    path = "/appropriate-body/claim-an-ect/check-ect/#{@pending_induction_submission.id}/edit"
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_confirm_the_details_are_correct
+    page.get_by_label('I have checked the information above and it looks accurate').check
+  end
+
+  def now_i_should_be_on_the_claim_an_ect_register_page
+    path = "/appropriate-body/claim-an-ect/register-ect/#{@pending_induction_submission.id}/edit"
+    expect(page.url).to end_with(path)
+  end
+
+  def when_i_enter_the_start_date
+    page.get_by_label('Day').fill('3')
+    page.get_by_label('Month').fill('4')
+    @start_year = Time.zone.today.year - 2
+    page.get_by_label('Year').fill(@start_year.to_s)
+  end
+
+  def and_choose_an_induction_programme
+    page.get_by_label("Full induction programme").check
+  end
+
+  def then_i_should_be_on_the_confirmation_page
+    path = "/appropriate-body/claim-an-ect/register-ect/#{@pending_induction_submission.id}"
+    expect(page.url).to end_with(path)
+  end
+
+  def and_the_data_i_submitted_should_be_saved_on_the_pending_record
+    @pending_induction_submission.reload.tap do |sub|
+      expect(sub.date_of_birth).to eql(Date.new(2003, 2, 1))
+      expect(sub.trs_first_name).to eql('Kirk')
+      expect(sub.trs_last_name).to eql('Van Houten')
+      expect(sub.started_on).to eql(Date.new(@start_year, 4, 3))
+    end
+  end
+
+  def if_i_submit_with_errors_the_errors_are_reported_to_me(expected_errors: nil)
+    when_i_submit_the_form
+
+    expect(page.title).to start_with('Error:')
+
+    error_summary = page.locator('.govuk-error-summary')
+
+    expect(error_summary).to be_present
+    expect(error_summary.locator('li').count).to eql(expected_errors)
+  end
+end

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT' do
   include AuthHelper
-  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { user.appropriate_bodies.first }
   let(:page_heading) { "Check details for" }
   let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
   let(:pending_induction_submission_id_param) { pending_induction_submission.id.to_s }
@@ -20,7 +20,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
     context 'when signed in as an appropriate body user' do
       # FIXME: we don't have appropriate body users yet so this is just making
       #        sure they're logged in
-      before { sign_in_as(:appropriate_body_user) }
+      let!(:user) { sign_in_as(:appropriate_body_user) }
 
       it 'finds the right PendingInductionSubmission record and renders the page' do
         allow(PendingInductionSubmission).to receive(:find).with(pending_induction_submission_id_param).and_call_original
@@ -44,7 +44,7 @@ RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT
     end
 
     context 'when signed in' do
-      before { sign_in_as(:appropriate_body_user) }
+      let!(:user) { sign_in_as(:appropriate_body_user) }
       before { allow(AppropriateBodies::ClaimAnECT::CheckECT).to receive(:new).with(any_args).and_call_original }
 
       context "when the submission is valid" do

--- a/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/check_ect_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe 'Appropriate body claiming an ECT: checking we have the right ECT' do
+  include AuthHelper
+  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:page_heading) { "Check details for" }
+  let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let(:pending_induction_submission_id_param) { pending_induction_submission.id.to_s }
+
+  describe 'GET /appropriate-body/claim-an-ect/check-ect/:id/edit' do
+    context 'when not signed in' do
+      it 'redirects to the signin page' do
+        get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
+
+        expect(response).to be_redirection
+        expect(response.redirect_url).to end_with('/sign-in')
+      end
+    end
+
+    context 'when signed in as an appropriate body user' do
+      # FIXME: we don't have appropriate body users yet so this is just making
+      #        sure they're logged in
+      before { sign_in_as(:appropriate_body_user) }
+
+      it 'finds the right PendingInductionSubmission record and renders the page' do
+        allow(PendingInductionSubmission).to receive(:find).with(pending_induction_submission_id_param).and_call_original
+
+        get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
+
+        expect(PendingInductionSubmission).to have_received(:find).with(pending_induction_submission_id_param).once
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'POST /appropriate-body/claim-an-ect/check-ect/:id' do
+    context 'when not signed in' do
+      it 'redirects to the signin page' do
+        patch("/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}")
+
+        expect(response).to be_redirection
+        expect(response.redirect_url).to end_with('/sign-in')
+      end
+    end
+
+    context 'when signed in' do
+      before { sign_in_as(:appropriate_body_user) }
+      before { allow(AppropriateBodies::ClaimAnECT::CheckECT).to receive(:new).with(any_args).and_call_original }
+
+      context "when the submission is valid" do
+        let(:confirmation_param) { { confirmed: "1", } }
+
+        before do
+          allow_any_instance_of(AppropriateBodies::ClaimAnECT::CheckECT).to receive(:confirm_info_correct).and_call_original
+        end
+
+        it 'passes the parameters to the AppropriateBodies::ClaimAnECT::CheckECT service and redirects' do
+          patch(
+            "/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}",
+            params: { appropriate_body:, pending_induction_submission: confirmation_param }
+          )
+
+          expect(AppropriateBodies::ClaimAnECT::CheckECT).to have_received(:new).with(
+            appropriate_body:,
+            pending_induction_submission_id: pending_induction_submission_id_param
+          )
+
+          expect(response).to be_redirection
+          expect(response.redirect_url).to match(%r{/claim-an-ect/register-ect/\d+/edit\z})
+        end
+
+        it 'calls AppropriateBodies::ClaimAnECT::CheckECT#confirm_info_correct' do
+          fake_check_ect = double(AppropriateBodies::ClaimAnECT::CheckECT, confirm_info_correct: pending_induction_submission)
+          allow(AppropriateBodies::ClaimAnECT::CheckECT).to receive(:new).and_return(fake_check_ect)
+
+          patch(
+            "/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}",
+            params: { appropriate_body:, pending_induction_submission: confirmation_param }
+          )
+
+          expect(fake_check_ect).to have_received(:confirm_info_correct).with(true).once
+        end
+      end
+
+      context "when the submission is invalid" do
+        let(:confirmation_param) { { confirmed: "0", } }
+        it 'passes the parameters to the AppropriateBodies::ClaimAnECT::CheckECT but does not redirect and rerenders the form' do
+          patch(
+            "/appropriate-body/claim-an-ect/check-ect/#{pending_induction_submission.id}",
+            params: { appropriate_body:, pending_induction_submission: confirmation_param }
+          )
+
+          expect(response).to be_ok
+          expect(response.body).to include(page_heading)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
-  let(:appropriate_body) { user.appropriate_bodies.first }
+  include_context 'fake_trs_api_client'
+
   let(:page_heading) { "Find an early career teacher" }
 
   describe 'GET /appropriate-body/claim-an-ect/find-ect' do
@@ -45,7 +46,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
       before { allow(AppropriateBodies::ClaimAnECT::FindECT).to receive(:new).with(any_args).and_call_original }
 
       let!(:user) { sign_in_as(:appropriate_body_user) }
-      let(:birth_year_param) { "2001" }
+      let(:appropriate_body) { user.appropriate_bodies.first }
 
       let(:search_params) do
         {
@@ -57,15 +58,17 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
       end
 
       context "when the submission is valid" do
+        let(:birth_year_param) { "2001" }
+
         it 'passes the parameters to the AppropriateBodies::ClaimAnECT::FindECT service and redirects' do
           post(
             '/appropriate-body/claim-an-ect/find-ect',
-            params: { appropriate_body:, pending_induction_submission: search_params }
+            params: { pending_induction_submission: search_params }
           )
 
           expect(AppropriateBodies::ClaimAnECT::FindECT).to have_received(:new).with(
             appropriate_body:,
-            pending_induction_submission_params: ActionController::Parameters.new(**search_params).permit!
+            pending_induction_submission: PendingInductionSubmission.last
           )
 
           expect(response).to be_redirection
@@ -79,7 +82,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
         it 'it re-renders the find page' do
           post(
             '/appropriate-body/claim-an-ect/find-ect',
-            params: { appropriate_body:, pending_induction_submission: search_params }
+            params: { pending_induction_submission: search_params }
           )
 
           expect(response).to be_ok

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
+  include AuthHelper
+  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:page_heading) { "Find an early career teacher" }
+
+  describe 'GET /appropriate-body/claim-an-ect/find-ect' do
+    context 'when not signed in' do
+      it 'redirects to the signin page' do
+        get('/appropriate-body/claim-an-ect/find-ect/new')
+
+        expect(response).to be_redirection
+        expect(response.redirect_url).to end_with('/sign-in')
+      end
+    end
+
+    context 'when signed in as an appropriate body user' do
+      # FIXME: we don't have appropriate body users yet so this is just making
+      #        sure they're logged in
+      before { sign_in_as(:appropriate_body_user) }
+
+      it 'instantiates a new PendingInductionSubmission and renders the page' do
+        allow(PendingInductionSubmission).to receive(:new).and_call_original
+
+        get('/appropriate-body/claim-an-ect/find-ect/new')
+
+        expect(response.body).to include(page_heading)
+        expect(PendingInductionSubmission).to have_received(:new).once
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'POST /appropriate-body/claim-an-ect/find-ect' do
+    context 'when not signed in' do
+      it 'redirects to the signin page' do
+        post('/appropriate-body/claim-an-ect/find-ect')
+
+        expect(response).to be_redirection
+        expect(response.redirect_url).to end_with('/sign-in')
+      end
+    end
+
+    context 'when signed in' do
+      before { sign_in_as(:appropriate_body_user) }
+      before { allow(AppropriateBodies::ClaimAnECT::FindECT).to receive(:new).with(any_args).and_call_original }
+
+      let(:birth_year_param) { "2001" }
+
+      let(:search_params) do
+        {
+          trn: "1234567",
+          "date_of_birth(3)" => "3",
+          "date_of_birth(2)" => "5",
+          "date_of_birth(1)" => birth_year_param,
+        }
+      end
+
+      context "when the submission is valid" do
+        it 'passes the parameters to the AppropriateBodies::ClaimAnECT::FindECT service and redirects' do
+          post(
+            '/appropriate-body/claim-an-ect/find-ect',
+            params: { appropriate_body:, pending_induction_submission: search_params }
+          )
+
+          expect(AppropriateBodies::ClaimAnECT::FindECT).to have_received(:new).with(
+            appropriate_body:,
+            pending_induction_submission_params: ActionController::Parameters.new(**search_params).permit!
+          )
+
+          expect(response).to be_redirection
+          expect(response.redirect_url).to match(%r{/claim-an-ect/check-ect/\d+/edit\z})
+        end
+      end
+
+      context "when the submission is invalid" do
+        let(:birth_year_param) { (Date.current.year - 2).to_s }
+
+        it 'it re-renders the find page' do
+          post(
+            '/appropriate-body/claim-an-ect/find-ect',
+            params: { appropriate_body:, pending_induction_submission: search_params }
+          )
+
+          expect(response).to be_ok
+          expect(response.body).to include(page_heading)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
   include AuthHelper
-  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:appropriate_body) { user.appropriate_bodies.first }
   let(:page_heading) { "Find an early career teacher" }
 
   describe 'GET /appropriate-body/claim-an-ect/find-ect' do
@@ -18,7 +18,7 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
     context 'when signed in as an appropriate body user' do
       # FIXME: we don't have appropriate body users yet so this is just making
       #        sure they're logged in
-      before { sign_in_as(:appropriate_body_user) }
+      let!(:user) { sign_in_as(:appropriate_body_user) }
 
       it 'instantiates a new PendingInductionSubmission and renders the page' do
         allow(PendingInductionSubmission).to receive(:new).and_call_original
@@ -43,9 +43,9 @@ RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
     end
 
     context 'when signed in' do
-      before { sign_in_as(:appropriate_body_user) }
       before { allow(AppropriateBodies::ClaimAnECT::FindECT).to receive(:new).with(any_args).and_call_original }
 
+      let!(:user) { sign_in_as(:appropriate_body_user) }
       let(:birth_year_param) { "2001" }
 
       let(:search_params) do

--- a/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/find_ect_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Appropriate body claiming an ECT: finding the ECT' do
-  include AuthHelper
   let(:appropriate_body) { user.appropriate_bodies.first }
   let(:page_heading) { "Find an early career teacher" }
 

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -1,0 +1,134 @@
+require 'rails_helper'
+
+RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
+  include AuthHelper
+  let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
+  let(:page_heading) { "Tell us about" }
+  let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }
+  let(:pending_induction_submission_id_param) { pending_induction_submission.id.to_s }
+
+  describe 'GET /appropriate-body/claim-an-ect/register-ect/:id/edit' do
+    context 'when not signed in' do
+      it 'redirects to the signin page' do
+        get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
+
+        expect(response).to be_redirection
+        expect(response.redirect_url).to end_with('/sign-in')
+      end
+    end
+
+    context 'when signed in as an appropriate body user' do
+      # FIXME: we don't have appropriate body users yet so this is just making
+      #        sure they're logged in
+      before { sign_in_as(:appropriate_body_user) }
+
+      it 'finds the right PendingInductionSubmission record and renders the page' do
+        allow(PendingInductionSubmission).to receive(:find).with(pending_induction_submission_id_param).and_call_original
+
+        get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/edit")
+
+        expect(PendingInductionSubmission).to have_received(:find).with(pending_induction_submission_id_param).once
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'POST /appropriate-body/claim-an-ect/register-ect/:id' do
+    context 'when not signed in' do
+      it 'redirects to the signin page' do
+        patch("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}")
+
+        expect(response).to be_redirection
+        expect(response.redirect_url).to end_with('/sign-in')
+      end
+    end
+
+    context 'when signed in' do
+      let!(:user) { sign_in_as(:appropriate_body_user) }
+      let(:appropriate_body) { user.appropriate_bodies.first }
+      before { allow(AppropriateBodies::ClaimAnECT::CheckECT).to receive(:new).with(any_args).and_call_original }
+      before { allow(AppropriateBodies::ClaimAnECT::RegisterECT).to receive(:new).with(any_args).and_call_original }
+
+      context 'when the submission is valid' do
+        let(:registration_params) do
+          {
+            induction_programme: 'fip',
+            'started_on(3)' => '4',
+            'started_on(2)' => '6',
+            'started_on(1)' => '2023'
+          }
+        end
+
+        before do
+          allow_any_instance_of(AppropriateBodies::ClaimAnECT::RegisterECT).to receive(:register).and_call_original
+        end
+
+        it 'passes the parameters to the AppropriateBodies::ClaimAnECT::RegisterECT service and redirects' do
+          patch(
+            "/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}",
+            params: { appropriate_body:, pending_induction_submission: registration_params }
+          )
+
+          expect(AppropriateBodies::ClaimAnECT::RegisterECT).to have_received(:new).with(
+            appropriate_body:,
+            pending_induction_submission_id: pending_induction_submission_id_param
+          )
+
+          expect(response).to be_redirection
+          expect(response.redirect_url).to match(%r{/claim-an-ect/register-ect/\d+\z})
+        end
+
+        it 'calls AppropriateBodies::ClaimAnECT::RegisterECT#register' do
+          fake_register_ect = double(AppropriateBodies::ClaimAnECT::RegisterECT, register: pending_induction_submission)
+          allow(AppropriateBodies::ClaimAnECT::RegisterECT).to receive(:new).and_return(fake_register_ect)
+
+          patch(
+            "/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}",
+            params: { appropriate_body:, pending_induction_submission: registration_params }
+          )
+
+          expect(fake_register_ect).to have_received(:register).with(
+            ActionController::Parameters.new(**registration_params).permit!
+          ).once
+        end
+      end
+
+      context "when the submission is invalid" do
+        let(:registration_params) { { induction_programme: "xyz", } }
+        it 'passes the parameters to the AppropriateBodies::ClaimAnECT::RegisterECT but does not redirect and rerenders the form' do
+          patch(
+            "/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}",
+            params: { appropriate_body:, pending_induction_submission: registration_params }
+          )
+
+          expect(response).to be_ok
+          expect(response.body).to include(page_heading)
+        end
+      end
+    end
+  end
+
+  describe 'GET /appropriate-body/claim-an-ect/register-ect/:id' do
+    context 'when not signed in' do
+      it 'redirects to the signin page' do
+        get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}")
+
+        expect(response).to be_redirection
+        expect(response.redirect_url).to end_with('/sign-in')
+      end
+    end
+
+    context 'when signed in' do
+      before { sign_in_as(:appropriate_body_user) }
+
+      it 'finds the right PendingInductionSubmission record and renders the page' do
+        allow(PendingInductionSubmission).to receive(:find).with(pending_induction_submission_id_param).and_call_original
+
+        get("/appropriate-body/claim-an-ect/register-ect/#{pending_induction_submission.id}/")
+
+        expect(PendingInductionSubmission).to have_received(:find).with(pending_induction_submission_id_param).once
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
+++ b/spec/requests/appropriate_bodies/claim_an_ect/register_ect_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Appropriate body claiming an ECT: registering the ECT' do
-  include AuthHelper
   let!(:appropriate_body) { FactoryBot.create(:appropriate_body) }
   let(:page_heading) { "Tell us about" }
   let!(:pending_induction_submission) { FactoryBot.create(:pending_induction_submission) }

--- a/spec/support/api/trs/fake_api_client.rb
+++ b/spec/support/api/trs/fake_api_client.rb
@@ -1,0 +1,17 @@
+module TRS
+  class FakeAPIClient
+    def find_teacher(trn:, date_of_birth:)
+      Rails.logger.info("TRSFakeAPIClient pretending to find teacher with TRN=#{trn} and Date of birth=#{date_of_birth}")
+
+      @trn = trn
+      @date_of_birth = date_of_birth
+
+      TRS::Teacher.new({
+        'trn' => trn,
+        'firstName' => 'Kirk',
+        'lastName' => 'Van Houten',
+        'dateOfBirth' => date_of_birth,
+      })
+    end
+  end
+end

--- a/spec/support/features/user_helper.rb
+++ b/spec/support/features/user_helper.rb
@@ -15,6 +15,12 @@ module UserHelper
     end
   end
 
+  def sign_in_as_appropriate_body_user
+    FactoryBot.create(:user, :appropriate_body_user, email: "appropriate-body@example.com", name: "Appropriate Body").tap do |user|
+      sign_in_as(user)
+    end
+  end
+
   def sign_out
     page.goto(otp_sign_out_path)
   end

--- a/spec/support/requests/auth_helper.rb
+++ b/spec/support/requests/auth_helper.rb
@@ -21,3 +21,5 @@ private
     end
   end
 end
+
+RSpec.configure { |config| config.include(AuthHelper, type: :request) }

--- a/spec/support/requests/auth_helper.rb
+++ b/spec/support/requests/auth_helper.rb
@@ -1,0 +1,24 @@
+module AuthHelper
+  def sign_in_as(user_type, method: :otp)
+    Rails.logger.info("logging in as #{user_type}")
+
+    case method
+    when :otp then sign_in_with_otp(user_type)
+    end
+  end
+
+private
+
+  def sign_in_with_otp(_user_type)
+    # TODO: once we have user types make sure this signs us in with the correct
+    #       kind of user
+    user = FactoryBot.create(:user)
+    post(otp_sign_in_path, params: { sessions_otp_sign_in_form: { email: user.email } })
+    post(
+      otp_sign_in_verify_path,
+      params: {
+        sessions_otp_sign_in_form: { code: Sessions::OneTimePassword.new(user:).generate },
+      }
+    )
+  end
+end

--- a/spec/support/requests/auth_helper.rb
+++ b/spec/support/requests/auth_helper.rb
@@ -9,16 +9,15 @@ module AuthHelper
 
 private
 
-  def sign_in_with_otp(_user_type)
-    # TODO: once we have user types make sure this signs us in with the correct
-    #       kind of user
-    user = FactoryBot.create(:user)
-    post(otp_sign_in_path, params: { sessions_otp_sign_in_form: { email: user.email } })
-    post(
-      otp_sign_in_verify_path,
-      params: {
-        sessions_otp_sign_in_form: { code: Sessions::OneTimePassword.new(user:).generate },
-      }
-    )
+  def sign_in_with_otp(user_type)
+    FactoryBot.create(:user, user_type).tap do |user|
+      post(otp_sign_in_path, params: { sessions_otp_sign_in_form: { email: user.email } })
+      post(
+        otp_sign_in_verify_path,
+        params: {
+          sessions_otp_sign_in_form: { code: Sessions::OneTimePassword.new(user:).generate },
+        }
+      )
+    end
   end
 end

--- a/spec/support/rspec_playwright.rb
+++ b/spec/support/rspec_playwright.rb
@@ -6,10 +6,22 @@ module RSpecPlaywright
 
   # rubocop:disable Rails/SaveBang
   def self.start_browser(javascript_enabled: false)
+    headless = ENV.fetch('HEADLESS', true).then do |h|
+      case
+      when h.in?([true, '1', 'yes', 'true'])
+        true
+      when h.in?([false, '0', 'no', 'false'])
+        false
+      else
+        fail(ArgumentError, 'Invalid headless option')
+      end
+    end
+
     browser = Playwright.create(playwright_cli_executable_path: PLAYWRIGHT_CLI_EXECUTABLE_PATH)
                         .playwright
                         .chromium
-                        .launch(headless: true)
+                        .launch(headless:)
+
     browser.new_page(baseURL: Capybara.current_session.server.base_url, javaScriptEnabled: javascript_enabled)
   end
   # rubocop:enable Rails/SaveBang

--- a/spec/support/shared_contexts/fake_trs_api_client.rb
+++ b/spec/support/shared_contexts/fake_trs_api_client.rb
@@ -1,0 +1,5 @@
+shared_context 'fake_trs_api_client' do
+  before do
+    allow(TRS::APIClient).to receive(:new).and_return(TRS::FakeAPIClient.new)
+  end
+end


### PR DESCRIPTION
Add features and request specs covering the AB claim flow written in #272.

This change also adds the `TRS::FakeAPIClient` which lets us get past the stage in the flow where we need to check TRS for someone's data. We should probably enable the fake client in development by default to ease testing.

Fixes #265 